### PR TITLE
Add use_reloader=False to startup

### DIFF
--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -1273,4 +1273,4 @@ INTERFACE.set_filter_ratio_global(tune_val.f_ratio)
 
 
 if __name__ == '__main__':
-    SOCKET_IO.run(APP, host='0.0.0.0', port=80, debug=True)
+    SOCKET_IO.run(APP, host='0.0.0.0', port=80, debug=True, use_reloader=False)


### PR DESCRIPTION
Every time "Delta5server/server.py" starts it would stop, show the 'Restarting with stat' message, and restart. Adding "use_reloader=False" to the 'SOCKET_IO.run()' parameters fixes it so it just starts up cleanly. Solution found in a comment here: https://stackoverflow.com/questions/28241989/flask-app-restarting-with-stat

--ET