### PR TITLE
Updates for 'nodeRssiPeak', per-node offsets, etc 

### DIFF
--- a/doc/Hardware and Software Setup Instructions.md
+++ b/doc/Hardware and Software Setup Instructions.md
@@ -56,12 +56,10 @@ Note: The latest Arduino IDE (1.8+) is required from https://www.arduino.cc/en/M
 
 Open '/delta5_race_timer/src/delta5node/delta5node.ino' in the Arduino IDE.
 
-Configure the '#define i2cSlaveAddress' line of the .ino for each node before uploading.
+Configure the '#define NODE_NUMBER' line of the .ino for each node before uploading. For first node set NODE_NUMBER to 1, for second set it to 2, etc.
 ```
-// Node Setup -- Set the i2c address here
-// Node 1 = 8, Node 2 = 10, Node 3 = 12, Node 4 = 14
-// Node 5 = 16, Node 6 = 18, Node 7 = 20, Node 8 = 22
-#define i2cSlaveAddress 8
+// Node Setup -- Set node number here (1 - 8)
+#define NODE_NUMBER 1
 ```
 
 ### System (Raspberry Pi)

--- a/src/delta5interface/BaseHardwareInterface.py
+++ b/src/delta5interface/BaseHardwareInterface.py
@@ -32,7 +32,8 @@ class BaseHardwareInterface(object):
     def get_heartbeat_json(self):
         return {
             'current_rssi': [node.current_rssi for node in self.nodes],
-            'loop_time': [node.loop_time for node in self.nodes]
+            'loop_time': [node.loop_time for node in self.nodes],
+            'crossing_flag': [node.crossing_flag for node in self.nodes]
         }
 
     def get_calibration_threshold_json(self):

--- a/src/delta5interface/Node.py
+++ b/src/delta5interface/Node.py
@@ -3,13 +3,18 @@
 class Node:
     '''Node class represents the arduino/rx pair.'''
     def __init__(self):
+        self.api_level = 0
+        self.api_lvl5_flag = False
         self.frequency = 0
         self.current_rssi = 0
         self.trigger_rssi = 0
-        self.peak_rssi = 0
+        self.node_peak_rssi = 0
+        self.pass_peak_rssi = 0
         self.node_offs_adj = 0
         self.last_lap_id = -1
         self.loop_time = 10
+        self.crossing_flag = False
+        self.debug_pass_count = 0
 
     def get_settings_json(self):
         return {
@@ -22,5 +27,5 @@ class Node:
         return {
             'current_rssi': self.current_rssi,
             'trigger_rssi': self.trigger_rssi,
-            'peak_rssi': self.peak_rssi
+            'pass_peak_rssi': self.pass_peak_rssi
         }

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -536,6 +536,7 @@ void i2cTransmit() {
 			ioBufferWrite16(state.nodeRssiPeak);  // as of API 5 return 'nodeRssiPeak' here
 			ioBufferWrite16(lastPass.rssiPeak);
 			ioBufferWrite32(state.loopTime);
+			ioBufferWrite8(state.crossing ? (uint8_t)1 : (uint8_t)0);  // as of API 5 return 'crossing' status
 			break;
 		case READ_CALIBRATION_THRESHOLD:
                    // no longer using this; but keep cmd for backward compatibility

--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -914,7 +914,9 @@ def emit_node_data():
     SOCKET_IO.emit('node_data', {
         'frequency': [node.frequency for node in INTERFACE.nodes],
         'trigger_rssi': [node.trigger_rssi for node in INTERFACE.nodes],
-        'peak_rssi': [node.peak_rssi for node in INTERFACE.nodes]
+        'node_peak_rssi': [node.node_peak_rssi for node in INTERFACE.nodes],
+        'pass_peak_rssi': [node.pass_peak_rssi for node in INTERFACE.nodes],
+        'debug_pass_count': [node.debug_pass_count for node in INTERFACE.nodes]
     })
 
 def emit_node_offsets():
@@ -1148,6 +1150,7 @@ def phonetictime_format(millis):
 def pass_record_callback(node, ms_since_lap):
     '''Handles pass records from the nodes.'''
     server_log('Raw pass record: Node: {0}, MS Since Lap: {1}'.format(node.index+1, ms_since_lap))
+    node.debug_pass_count += 1
     emit_node_data() # For updated triggers and peaks
 
     node_data = NodeData.query.filter_by(id=node.index).first()

--- a/src/delta5server/templates/correction.html
+++ b/src/delta5server/templates/correction.html
@@ -259,7 +259,6 @@
 				$('#s_channel_' + i).val(msg.frequency[i]);
 				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
 				$('.peak_rssi_' + i).html(msg.peak_rssi[i]);
-				$('#set_node_offset_' + i).val(msg.node_offset[i]);
 
 				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				var freqExists = $('#f_table_' + i + ' option[value=' + msg.frequency[i] + ']').length;
@@ -272,9 +271,15 @@
 				d5rt.nodes[i].peak_rssi = msg.peak_rssi[i];
 				d5rt.nodes[i].calibration_threshold = msg.trigger_rssi[i] - parseInt($('#set_calibration_threshold').val());
 				d5rt.nodes[i].trigger_threshold = msg.trigger_rssi[i] - parseInt($('#set_trigger_threshold').val());
-				d5rt.nodes[i].offset = msg.node_offset[i];
 
 				d5rt.nodes[i].updateThresholds();
+			}
+		});
+
+		socket.on('node_offsets', function (msg) {
+			for (i = 0; i < msg.node_offsets.length; i++) {
+				$('#set_node_offset_' + i).val(msg.node_offsets[i]);
+				d5rt.nodes[i].offset = msg.node_offsets[i];
 			}
 		});
 

--- a/src/delta5server/templates/correction.html
+++ b/src/delta5server/templates/correction.html
@@ -258,7 +258,8 @@
 			for (i = 0; i < msg.frequency.length; i++) {
 				$('#s_channel_' + i).val(msg.frequency[i]);
 				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
-				$('.peak_rssi_' + i).html(msg.peak_rssi[i]);
+				$('.node_peak_rssi_' + i).html(msg.node_peak_rssi[i]);
+				$('.pass_peak_rssi_' + i).html(msg.pass_peak_rssi[i]);
 
 				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				var freqExists = $('#f_table_' + i + ' option[value=' + msg.frequency[i] + ']').length;
@@ -268,7 +269,8 @@
 					$('#f_table_' + i).val('n/a');
 				}
 
-				d5rt.nodes[i].peak_rssi = msg.peak_rssi[i];
+				d5rt.nodes[i].node_peak_rssi = msg.node_peak_rssi[i];
+				d5rt.nodes[i].pass_peak_rssi = msg.pass_peak_rssi[i];
 				d5rt.nodes[i].calibration_threshold = msg.trigger_rssi[i] - parseInt($('#set_calibration_threshold').val());
 				d5rt.nodes[i].trigger_threshold = msg.trigger_rssi[i] - parseInt($('#set_trigger_threshold').val());
 
@@ -429,9 +431,15 @@
 				</td>
 			</tr>
 			<tr>
-				<td class="datalabel">Peak</td>
+				<td class="datalabel">Node Peak</td>
 				<td>
-					<span class="peak_rssi_{{ node }}"></span>
+					<span class="node_peak_rssi_{{ node }}"></span>
+				</td>
+			</tr>
+			<tr>
+				<td class="datalabel">Pass Peak</td>
+				<td>
+					<span class="pass_peak_rssi_{{ node }}"></span>
 				</td>
 			</tr>
 		</table>

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -11,7 +11,6 @@
 
 	var racedump = {
 		timestamp: new Date(),
-		offsets: [],
 		timedata: [],
 	};
 
@@ -117,7 +116,6 @@
 				d5rt.nodes[i].frequency = msg.frequency[i];
 				d5rt.nodes[i].peak_rssi = msg.peak_rssi[i];
 				// import calibration/trigger threshold lines?
-				d5rt.nodes[i].offset = msg.node_offset[i];
 
 				d5rt.nodes[i].updateThresholds();
 
@@ -127,8 +125,6 @@
 				if (d5rt.nodes[i].frequency == 0) {
 					channelBlock.children('.fr').html('');
 				}
-
-				racedump.offsets[i] = msg.node_offset[i];
 			}
 		});
 

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -110,11 +110,13 @@
 		socket.on('node_data', function (msg) {
 			for (i = 0; i < msg.frequency.length; i++) {
 				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
-				$('.peak_rssi_' + i).html(msg.peak_rssi[i]);
+				$('.node_peak_rssi_' + i).html(msg.node_peak_rssi[i]);
+				$('.pass_peak_rssi_' + i).html(msg.pass_peak_rssi[i]);
 
 				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				d5rt.nodes[i].frequency = msg.frequency[i];
-				d5rt.nodes[i].peak_rssi = msg.peak_rssi[i];
+				d5rt.nodes[i].node_peak_rssi = msg.node_peak_rssi[i];
+				d5rt.nodes[i].pass_peak_rssi = msg.pass_peak_rssi[i];
 				// import calibration/trigger threshold lines?
 
 				d5rt.nodes[i].updateThresholds();
@@ -477,7 +479,8 @@
 							<td class="rssi" colspan="2">
 								<span class="current_rssi_{{ node }}"></span> /
 								<span class="trigger_rssi_{{ node }}"></span> /
-								<span class="peak_rssi_{{ node }}"></span>
+								<span class="node_peak_rssi_{{ node }}"></span> /
+								<span class="pass_peak_rssi_{{ node }}"></span>
 							</td>
 						</tr>
 					</thead>

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -33,6 +33,13 @@
 
 				$('.current_rssi_' + i).html(rssiValue);
 
+				if (msg.crossing_flag[i]) {
+					$('.crossing_flag_' + i).html(1);
+				}
+				else {
+					$('.crossing_flag_' + i).html(0);
+				}
+
 				if (d5rt.nodes[i].graph.options.maxValue < rssiValue) {
 					d5rt.nodes[i].graph.options.maxValue = rssiValue;
 				}
@@ -57,7 +64,9 @@
 			for (i = 0; i < msg.frequency.length; i++) {
 				$('#s_channel_' + i).val(msg.frequency[i]);
 				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
-				$('.peak_rssi_' + i).html(msg.peak_rssi[i]);
+				$('.node_peak_rssi_' + i).html(msg.node_peak_rssi[i]);
+				$('.pass_peak_rssi_' + i).html(msg.pass_peak_rssi[i]);
+				$('.debug_pass_count_' + i).html(msg.debug_pass_count[i]);
 
 				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				var freqExists = $('#f_table_' + i + ' option[value=' + msg.frequency[i] + ']').length;
@@ -68,7 +77,8 @@
 				}
 
 				d5rt.nodes[i].frequency = msg.frequency[i];
-				d5rt.nodes[i].peak_rssi = msg.peak_rssi[i];
+				d5rt.nodes[i].node_peak_rssi = msg.node_peak_rssi[i];
+				d5rt.nodes[i].pass_peak_rssi = msg.pass_peak_rssi[i];
 				/*
 				d5rt.nodes[i].calibration_threshold = msg.trigger_rssi[i] - parseInt($('#set_calibration_threshold').val());
 				d5rt.nodes[i].trigger_threshold = msg.trigger_rssi[i] - parseInt($('#set_trigger_threshold').val());
@@ -529,9 +539,27 @@
 						</td>
 					</tr>
 					<tr>
-						<td class="datalabel">Peak</td>
+						<td class="datalabel">NodePeak</td>
 						<td>
-							<span class="peak_rssi_{{ node }}"></span>
+							<span class="node_peak_rssi_{{ node }}"></span>
+						</td>
+					</tr>
+					<tr>
+						<td class="datalabel">PassPeak</td>
+						<td>
+							<span class="pass_peak_rssi_{{ node }}"></span>
+						</td>
+					</tr>
+					<tr>
+						<td class="datalabel">PassCount</td>
+						<td>
+							<span class="debug_pass_count_{{ node }}"></span>
+						</td>
+					</tr>
+					<tr>
+						<td class="datalabel">Crossing</td>
+						<td>
+							<span class="crossing_flag_{{ node }}"></span>
 						</td>
 					</tr>
 				</table>

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -58,7 +58,6 @@
 				$('#s_channel_' + i).val(msg.frequency[i]);
 				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
 				$('.peak_rssi_' + i).html(msg.peak_rssi[i]);
-				$('#set_node_offset_' + i).val(msg.node_offset[i]);
 
 				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				var freqExists = $('#f_table_' + i + ' option[value=' + msg.frequency[i] + ']').length;
@@ -74,7 +73,6 @@
 				d5rt.nodes[i].calibration_threshold = msg.trigger_rssi[i] - parseInt($('#set_calibration_threshold').val());
 				d5rt.nodes[i].trigger_threshold = msg.trigger_rssi[i] - parseInt($('#set_trigger_threshold').val());
 				*/
-				d5rt.nodes[i].offset = msg.node_offset[i];
 
 				d5rt.nodes[i].updateThresholds();
 			}
@@ -85,6 +83,13 @@
 				var node = $(this).data('node');
 				var frequency = parseInt($(this).val());
 				$('#s_channel_' + node).val(frequency).trigger('change');
+			}
+		});
+
+		socket.on('node_offsets', function (msg) {
+			for (i = 0; i < msg.node_offsets.length; i++) {
+				$('#set_node_offset_' + i).val(msg.node_offsets[i]);
+				d5rt.nodes[i].offset = msg.node_offsets[i];
 			}
 		});
 

--- a/src/timingserver/server.py
+++ b/src/timingserver/server.py
@@ -278,8 +278,9 @@ def pass_record_callback(node, ms_since_lap):
         'frequency': node.frequency,
         'timestamp': hardwareInterface.milliseconds() - ms_since_lap,
         'trigger_rssi': node.trigger_rssi,
-        'peak_rssi_raw': node.peak_rssi_raw,
-        'peak_rssi': node.peak_rssi})
+        'peak_rssi_raw': node.pass_peak_rssi,  # 'peak_rssi_raw' no longer read from node
+        'pass_peak_rssi': node.pass_peak_rssi,
+        'node_peak_rssi': node.node_peak_rssi})
     if node.index==0:
         theaterChase(strip, Color(0,0,255))  #BLUE theater chase
     elif node.index==1:

--- a/src/timingserver/templates/index.html
+++ b/src/timingserver/templates/index.html
@@ -84,8 +84,8 @@
             reset = function() {
                 for (i=0; i<num_nodes; i++) {
                     $('#lap_table_' + i).empty();
-                    $('#peak_rssi_' + i).html(0);
-                    $('#peak_rssi_bar_' + i).css("width", normalize_rssi(0)+'%');
+                    $('#pass_peak_rssi_' + i).html(0);
+                    $('#pass_peak_rssi_bar_' + i).css("width", normalize_rssi(0)+'%');
                     $('#trigger_rssi_' + i).html(0);
                     $('#trigger_rssi_bar_' + i).css("width", normalize_rssi(0)+'%');
                 }
@@ -166,8 +166,8 @@
                                 </div>
                             </form>
                             <div class="progress">
-                              <div id="peak_rssi_bar_${index}" class="progress-bar progress-bar-info" role="progressbar" style="width: 0%">
-                                <span id='peak_rssi_${index}'>0</span>
+                              <div id="pass_peak_rssi_bar_${index}" class="progress-bar progress-bar-info" role="progressbar" style="width: 0%">
+                                <span id='pass_peak_rssi_${index}'>0</span>
                               </div>
                             </div>
                             <div class="progress">
@@ -272,11 +272,11 @@
                 var time_lap = msg.timestamp - last_lap_timestamp[msg.node];
                 var time_total = msg.timestamp - start_timestamp[msg.node];
                 last_lap_timestamp[msg.node] = msg.timestamp;
-                lap_table.append(Lap(lap_table[0].children.length, msg.peak_rssi, ms_to_time(time_lap), ms_to_time(time_total)));
+                lap_table.append(Lap(lap_table[0].children.length, msg.pass_peak_rssi, ms_to_time(time_lap), ms_to_time(time_total)));
                 append_to_log('on pass_record ' + JSON.stringify(msg));
 
-                $('#peak_rssi_' + msg.node).html(msg.peak_rssi);
-                $('#peak_rssi_bar_' + msg.node).css("width", normalize_rssi(msg.peak_rssi)+'%');
+                $('#pass_peak_rssi_' + msg.node).html(msg.pass_peak_rssi);
+                $('#pass_peak_rssi_bar_' + msg.node).css("width", normalize_rssi(msg.pass_peak_rssi)+'%');
                 $('#trigger_rssi_' + msg.node).html(msg.trigger_rssi);
                 $('#trigger_rssi_bar_' + msg.node).css("width", normalize_rssi(msg.trigger_rssi)+'%');
             });


### PR DESCRIPTION
**Node ino updates for 'nodeRssiPeak', etc**

Added NODE_NUMBER define so node ID can be entered as 1 to 8 value instead of I2C address, and updated doc.

Removed SCALE commands.

Added 'nodeRssiPeak' that constantly tracks peak RSSI for node, and is persisted.  The 'nodeRssiPeak' value is reset when the node frequency is changed.

Added READ_NODE_RSSI_PEAK command.

Added READ_REVISION_CODE command.

Added FILTER_RATIO_DIVIDER and increased value from 1000.0 to 10000.0; default 'filterRatio' will result in 10X filtering effect, which is an improvement.

Modified READ_LAP_STATS to return 'nodeRssiPeak' in place of 'lastPass.rssiPeakRaw'


**Initial mods for per-node offsets**

Added separate update-emit for per-node offsets

Added periodic update of node-data values (so displayed 'Trigger' values change in response to adjusts to per-node offsets)


**More mods for per-node offsets**

Read new 'API_level' value from node
Read new 'node_peak' value from node
Renamed Node 'peak_rssi' field to 'pass_peak_rssi'
Added 'NodePeak' display
Added debug 'PassCount' display
Read and display new 'crossing' flag value from node

--ET