### PR TITLE
Rework to use EnterAt/ExitAt with capture

### DIFF
--- a/src/delta5interface/Delta5Interface.py
+++ b/src/delta5interface/Delta5Interface.py
@@ -438,8 +438,9 @@ class Delta5Interface(BaseHardwareInterface):
             return True
         return False
 
-    def intf_simulate_lap(self, node_index):
+    def intf_simulate_lap(self, node_index, ms_val):
         node = self.nodes[node_index]
+        node.lap_ms_since_start = ms_val
         self.pass_record_callback(node, 100)
 
 def get_hardware_interface():

--- a/src/delta5interface/Delta5Interface.py
+++ b/src/delta5interface/Delta5Interface.py
@@ -161,7 +161,10 @@ class Delta5Interface(BaseHardwareInterface):
                         node.current_rssi = rssi_val
                         
                         if node.api_valid_flag:  # if newer API functions supported
-                            node.lap_ms_since_start = unpack_32(data[1:])
+                            ms_val = unpack_32(data[1:])
+                            if ms_val < 0 or ms_val > 9999999:
+                                ms_val = 0  # don't allow negative or too-large value
+                            node.lap_ms_since_start = ms_val
                             node.node_peak_rssi = unpack_16(data[7:])
                             node.pass_peak_rssi = unpack_16(data[9:])
                             node.loop_time = unpack_32(data[11:])

--- a/src/delta5interface/Delta5Interface.py
+++ b/src/delta5interface/Delta5Interface.py
@@ -7,30 +7,31 @@ from gevent.lock import BoundedSemaphore # To limit i2c calls
 from Node import Node
 from BaseHardwareInterface import BaseHardwareInterface
 
-READ_ADDRESS = 0x00 # Gets i2c address of arduino (1 byte)
-READ_FREQUENCY = 0x03 # Gets channel frequency (2 byte)
+READ_ADDRESS = 0x00         # Gets i2c address of arduino (1 byte)
+READ_FREQUENCY = 0x03       # Gets channel frequency (2 byte)
 READ_LAP_STATS = 0x05
-READ_CALIBRATION_THRESHOLD = 0x15
-READ_CALIBRATION_MODE = 0x16
-READ_CALIBRATION_OFFSET = 0x17
-READ_TRIGGER_THRESHOLD = 0x18
-READ_FILTER_RATIO = 0x19
+READ_FILTER_RATIO = 0x20    # node API_level>=10 uses 16-bit value
 READ_REVISION_CODE = 0x22   # read NODE_API_LEVEL and verification value
 READ_NODE_RSSI_PEAK = 0x23  # read 'nodeRssiPeak' value
+READ_ENTER_AT_LEVEL = 0x31
+READ_EXIT_AT_LEVEL = 0x32
+READ_TIME_MILLIS = 0x33     # read current 'millis()' time value
 
-WRITE_FREQUENCY = 0x51 # Sets frequency (2 byte)
-WRITE_CALIBRATION_THRESHOLD = 0x65
-WRITE_CALIBRATION_MODE = 0x66
-WRITE_CALIBRATION_OFFSET = 0x67
-WRITE_TRIGGER_THRESHOLD = 0x68
-WRITE_FILTER_RATIO = 0x69
+WRITE_FREQUENCY = 0x51      # Sets frequency (2 byte)
+WRITE_FILTER_RATIO = 0x70   # node API_level>=10 uses 16-bit value
+WRITE_ENTER_AT_LEVEL = 0x71
+WRITE_EXIT_AT_LEVEL = 0x72
+MARK_START_TIME = 0x77      # mark base time for returned lap-ms-since-start values
 
 UPDATE_SLEEP = 0.1 # Main update loop delay
 
-FREQ_ADJLIMIT_MHZ = 5645 # Below this freq do RSSI offset adj
-
 I2C_CHILL_TIME = 0.075 # Delay after i2c read/write
 I2C_RETRY_COUNT = 5 # Limit of i2c retries
+
+MIN_RSSI_VALUE = 1               # reject RSSI readings below this value
+MAX_RSSI_VALUE = 999             # reject RSSI readings above this value
+CAP_ENTER_EXIT_AT_MILLIS = 3000  # number of ms for capture of enter/exit-at levels
+ENTER_AT_PEAK_MARGIN = 5         # closest that captured enter-at level can be to node peak RSSI
 
 def unpack_8(data):
     return data[0]
@@ -72,6 +73,7 @@ class Delta5Interface(BaseHardwareInterface):
         self.update_thread = None # Thread for running the main update loop
         self.pass_record_callback = None # Function added in server.py
         self.hardware_log_callback = None # Function added in server.py
+        self.new_enter_or_exit_at_callback = None # Function added in server.py
 
         self.i2c = smbus.SMBus(1) # Start i2c bus
         self.semaphore = BoundedSemaphore(1) # Limits i2c to 1 read/write at a time
@@ -101,26 +103,21 @@ class Delta5Interface(BaseHardwareInterface):
                 node.api_level = rev_val & 0xFF
             else:
                 node.api_level = 0  # if verify failed (fn not defined) then set API level to 0
-            if node.api_level >= 5:
-                node.api_lvl5_flag = True  # set flag for API level 5 functions supported
+            if node.api_level >= 10:
+                node.api_valid_flag = True  # set flag for newer API functions supported
                 node.node_peak_rssi = self.get_value_16(node, READ_NODE_RSSI_PEAK)
-                print "Node {0}: API_level={1}, node_peak={2}, freq={3}".format(node.index+1, node.api_level, node.node_peak_rssi, node.frequency)
+                node.enter_at_level = self.get_value_16(node, READ_ENTER_AT_LEVEL)
+                node.exit_at_level = self.get_value_16(node, READ_EXIT_AT_LEVEL)
+                print "Node {0}: API_level={1}, Freq={2}, EnterAt={3}, ExitAt={4}".format(node.index+1, node.api_level, node.frequency, node.enter_at_level, node.exit_at_level)
             else:
-                print "Node {0}: API_level=0".format(node.index+1)
-            node.node_offs_adj = 0
+                print "Node {0}: API_level={1}".format(node.index+1, node.api_level)
             if node.index == 0:
-                self.calibration_threshold = self.get_value_16(node,
-                    READ_CALIBRATION_THRESHOLD)
-                self.calibration_offset = self.get_value_16(node,
-                    READ_CALIBRATION_OFFSET)
-                self.trigger_threshold = self.get_value_16(node,
-                    READ_TRIGGER_THRESHOLD)
-                self.filter_ratio = self.get_value_8(node,
-                    READ_FILTER_RATIO)
+                if node.api_valid_flag:
+                    self.filter_ratio = self.get_value_16(node, READ_FILTER_RATIO)
+                else:
+                    self.filter_ratio = 10
             else:
-                self.set_calibration_threshold(node.index, self.calibration_threshold)
-                self.set_calibration_offset(node.index, self.calibration_offset)
-                self.set_trigger_threshold(node.index, self.trigger_threshold)
+                self.set_filter_ratio(node.index, self.filter_ratio)
 
 
     #
@@ -149,30 +146,69 @@ class Delta5Interface(BaseHardwareInterface):
 
     def update(self):
         for node in self.nodes:
-            if node.api_lvl5_flag:
-                data = self.read_block(node.i2c_addr, READ_LAP_STATS, 18)
-            else:
-                data = self.read_block(node.i2c_addr, READ_LAP_STATS, 17)
-            if data != None:
-                lap_id = data[0]
-                ms_since_lap = unpack_32(data[1:])
-                node.current_rssi = unpack_16(data[5:])
-                node.trigger_rssi = unpack_16(data[7:])
-                if node.api_lvl5_flag:  # if supported then load 'nodeRssiPeak' value
-                    node.node_peak_rssi = unpack_16(data[9:])
-                node.pass_peak_rssi = unpack_16(data[11:])
-                node.loop_time = unpack_32(data[13:])
-                if node.api_lvl5_flag:  # if supported then load 'crossing' status
-                     if data[17]:
-                         node.crossing_flag = True
-                     else:
-                         node.crossing_flag = False
+            if node.frequency:
+                if node.api_valid_flag or node.api_level >= 5:
+                    data = self.read_block(node.i2c_addr, READ_LAP_STATS, 18)
+                else:
+                    data = self.read_block(node.i2c_addr, READ_LAP_STATS, 17)
+    
+                if data != None:
+                    lap_id = data[0]
+                    lap_time_ms = 0
 
-                if lap_id != node.last_lap_id:
-                    if node.last_lap_id != -1 and callable(self.pass_record_callback):
-                        self.pass_record_callback(node, ms_since_lap)
-                    node.last_lap_id = lap_id
-
+                    rssi_val = unpack_16(data[5:])
+                    if rssi_val >= MIN_RSSI_VALUE and rssi_val <= MAX_RSSI_VALUE:
+                        node.current_rssi = rssi_val
+                        
+                        if node.api_valid_flag:  # if newer API functions supported
+                            node.lap_ms_since_start = unpack_32(data[1:])
+                            node.node_peak_rssi = unpack_16(data[7:])
+                            node.pass_peak_rssi = unpack_16(data[9:])
+                            node.loop_time = unpack_32(data[11:])
+                            if data[15]:
+                                node.crossing_flag = True
+                            else:
+                                node.crossing_flag = False
+                            node.pass_nadir_rssi = unpack_16(data[16:])
+        
+                        else:  # if newer API functions not supported
+                            lap_time_ms = unpack_32(data[1:])
+                            node.pass_peak_rssi = unpack_16(data[11:])
+                            node.loop_time = unpack_32(data[13:])
+        
+                        # check if new lap detected for node
+                        if lap_id != node.last_lap_id:
+                            if node.last_lap_id != -1 and callable(self.pass_record_callback):
+                                self.pass_record_callback(node, lap_time_ms)
+                            node.last_lap_id = lap_id
+        
+                        # check if capturing enter-at level for node
+                        if node.cap_enter_at_flag:
+                            node.cap_enter_at_total += node.current_rssi
+                            node.cap_enter_at_count += 1
+                            if self.milliseconds() >= node.cap_enter_at_millis:
+                                node.enter_at_level = int(round(node.cap_enter_at_total / node.cap_enter_at_count))
+                                node.cap_enter_at_flag = False
+                                      # if too close node peak then set a bit below node-peak RSSI value:
+                                if node.node_peak_rssi > 0 and node.node_peak_rssi - node.enter_at_level < ENTER_AT_PEAK_MARGIN:
+                                    node.enter_at_level = node.node_peak_rssi - ENTER_AT_PEAK_MARGIN
+                                self.transmit_enter_at_level(node, node.enter_at_level)
+                                if callable(self.new_enter_or_exit_at_callback):
+                                    self.new_enter_or_exit_at_callback(node, True)
+        
+                        # check if capturing exit-at level for node
+                        if node.cap_exit_at_flag:
+                            node.cap_exit_at_total += node.current_rssi
+                            node.cap_exit_at_count += 1
+                            if self.milliseconds() >= node.cap_exit_at_millis:
+                                node.exit_at_level = int(round(node.cap_exit_at_total / node.cap_exit_at_count))
+                                node.cap_exit_at_flag = False
+                                self.transmit_exit_at_level(node, node.exit_at_level)
+                                if callable(self.new_enter_or_exit_at_callback):
+                                    self.new_enter_or_exit_at_callback(node, False)
+                    else:
+                        self.log('RSSI reading ({0}) out of range on Node {1}; rejected'.format(rssi_val, node.index+1))
+                        
     #
     # I2C Common Functions
     #
@@ -203,10 +239,20 @@ class Delta5Interface(BaseHardwareInterface):
                     else:
                         # self.log('Invalid Checksum ({0}): {1}'.format(retry_count, data))
                         retry_count = retry_count + 1
+                        if retry_count < I2C_RETRY_COUNT:
+                            if retry_count > 1:  # don't log the occasional single retry
+                                self.log('Retry (checksum) in read_block:  addr={0} offs={1} size={2} retry={3} ts={4}'.format(addr, offset, size, retry_count, self.i2c_timestamp))
+                        else:
+                            self.log('Retry (checksum) limit reached in read_block:  addr={0} offs={1} size={2} retry={3} ts={4}'.format(addr, offset, size, retry_count, self.i2c_timestamp))
             except IOError as err:
                 self.log(err)
                 self.i2c_timestamp = self.milliseconds()
                 retry_count = retry_count + 1
+                if retry_count < I2C_RETRY_COUNT:
+                    if retry_count > 1:  # don't log the occasional single retry
+                        self.log('Retry (IOError) in read_block:  addr={0} offs={1} size={2} retry={3} ts={4}'.format(addr, offset, size, retry_count, self.i2c_timestamp))
+                else:
+                    self.log('Retry (IOError) limit reached in read_block:  addr={0} offs={1} size={2} retry={3} ts={4}'.format(addr, offset, size, retry_count, self.i2c_timestamp))
         return data
 
     def write_block(self, addr, offset, data):
@@ -227,10 +273,14 @@ class Delta5Interface(BaseHardwareInterface):
                 self.log(err)
                 self.i2c_timestamp = self.milliseconds()
                 retry_count = retry_count + 1
+                if retry_count < I2C_RETRY_COUNT:
+                    self.log('Retry (IOError) in write_block:  addr={0} offs={1} data={2} retry={3} ts={4}'.format(addr, offset, data, retry_count, self.i2c_timestamp))
+                else:
+                    self.log('Retry (IOError) limit reached in write_block:  addr={0} offs={1} data={2} retry={3} ts={4}'.format(addr, offset, data, retry_count, self.i2c_timestamp))
         return success
 
     #
-    # Internal helper fucntions for setting single values
+    # Internal helper functions for setting single values
     #
 
     def get_value_8(self, node, command):
@@ -282,108 +332,71 @@ class Delta5Interface(BaseHardwareInterface):
             out_value = in_value
         return out_value
 
+    def set_value_8(self, node, write_command, in_value):
+        success = False
+        retry_count = 0
+        out_value = None
+        while success is False and retry_count < I2C_RETRY_COUNT:
+            if self.write_block(node.i2c_addr, write_command, pack_8(in_value)):
+                success = True
+            else:
+                retry_count = retry_count + 1
+                self.log('Value Not Set ({0}): {1}/{2}/{3}'.format(retry_count, write_command, in_value, node))
+        return success
+
     #
     # External functions for setting data
     #
 
-    def set_freq_and_offs(self, node_index, frequency, node_offs_adj):
-        node = self.nodes[node_index]
-        node.node_offs_adj = node_offs_adj
-        node.frequency = self.set_and_validate_value_16(node,
-            WRITE_FREQUENCY,
-            READ_FREQUENCY,
-            frequency)
-
     def set_frequency(self, node_index, frequency):
         node = self.nodes[node_index]
-        upd_flg = False
-        
-        # if lower frequency then call 'set_calibration_offset()' to update node offset
-        if frequency < FREQ_ADJLIMIT_MHZ or node.frequency < FREQ_ADJLIMIT_MHZ:
-            upd_flg = True
-
+        node.debug_pass_count = 0  # reset debug pass count on frequency change
         node.frequency = self.set_and_validate_value_16(node,
             WRITE_FREQUENCY,
             READ_FREQUENCY,
             frequency)
 
-        if upd_flg:
-            self.set_calibration_offset(node_index, self.calibration_offset)
+    def transmit_enter_at_level(self, node, level):
+        return self.set_and_validate_value_16(node,
+            WRITE_ENTER_AT_LEVEL,
+            READ_ENTER_AT_LEVEL,
+            level)
 
-    def chg_node_offs_adj(self, node_index, node_offs_adj):
+    def set_enter_at_level(self, node_index, level):
         node = self.nodes[node_index]
-        if node_offs_adj != node.node_offs_adj:
-            node.node_offs_adj = node_offs_adj
-            self.set_calibration_offset(node.index, self.calibration_offset)
+        if node.api_valid_flag:
+            node.enter_at_level = self.transmit_enter_at_level(node, level)
 
-    def set_calibration_threshold(self, node_index, threshold):
+    def transmit_exit_at_level(self, node, level):
+        return self.set_and_validate_value_16(node,
+            WRITE_EXIT_AT_LEVEL,
+            READ_EXIT_AT_LEVEL,
+            level)
+
+    def set_exit_at_level(self, node_index, level):
         node = self.nodes[node_index]
-        node.calibration_threshold = self.set_and_validate_value_16(node,
-            WRITE_CALIBRATION_THRESHOLD,
-            READ_CALIBRATION_THRESHOLD,
-            threshold)
+        if node.api_valid_flag:
+            node.exit_at_level = self.transmit_exit_at_level(node, level)
 
     def set_calibration_threshold_global(self, threshold):
-        self.calibration_threshold = threshold
-        for node in self.nodes:
-            self.set_calibration_threshold(node.index, threshold)
-        return self.calibration_threshold
-
-    def set_calibration_mode(self, node_index, calibration_mode):
-        node = self.nodes[node_index]
-        self.set_and_validate_value_8(node,
-            WRITE_CALIBRATION_MODE,
-            READ_CALIBRATION_MODE,
-            calibration_mode)
+        return threshold  # dummy function; no longer supported
 
     def enable_calibration_mode(self):
-        for node in self.nodes:
-            self.set_calibration_mode(node.index, True);
-
-    def set_calibration_offset(self, node_index, offset):
-        node = self.nodes[node_index]
-        
-        # if there's an RSSI-offset for this node then apply it
-        if node.node_offs_adj != 0:
-            offset = offset + node.node_offs_adj
-
-        # if lower frequency then apply extra RSSI-offset
-        if node.frequency > 0 and node.frequency < FREQ_ADJLIMIT_MHZ:
-            adj_val = (FREQ_ADJLIMIT_MHZ - node.frequency) / 10
-            if adj_val > 40:
-                adj_val = 40
-            offset = offset + adj_val
-            
-        node.calibration_offset = self.set_and_validate_value_16(node,
-            WRITE_CALIBRATION_OFFSET,
-            READ_CALIBRATION_OFFSET,
-            offset)
+        pass  # dummy function; no longer supported
 
     def set_calibration_offset_global(self, offset):
-        self.calibration_offset = offset
-        for node in self.nodes:
-            self.set_calibration_offset(node.index, offset)
-        return self.calibration_offset
-
-    def set_trigger_threshold(self, node_index, threshold):
-        node = self.nodes[node_index]
-        node.trigger_threshold = self.set_and_validate_value_16(node,
-            WRITE_TRIGGER_THRESHOLD,
-            READ_TRIGGER_THRESHOLD,
-            threshold)
+        return offset  # dummy function; no longer supported
 
     def set_trigger_threshold_global(self, threshold):
-        self.trigger_threshold = threshold
-        for node in self.nodes:
-            self.set_trigger_threshold(node.index, threshold)
-        return self.trigger_threshold
+        return threshold  # dummy function; no longer supported
 
     def set_filter_ratio(self, node_index, filter_ratio):
         node = self.nodes[node_index]
-        node.filter_ratio = self.set_and_validate_value_8(node,
-            WRITE_FILTER_RATIO,
-            READ_FILTER_RATIO,
-            filter_ratio)
+        if node.api_valid_flag:
+            node.filter_ratio = self.set_and_validate_value_16(node,
+                WRITE_FILTER_RATIO,
+                READ_FILTER_RATIO,
+                filter_ratio)
 
     def set_filter_ratio_global(self, filter_ratio):
         self.filter_ratio = filter_ratio
@@ -391,13 +404,39 @@ class Delta5Interface(BaseHardwareInterface):
             self.set_filter_ratio(node.index, filter_ratio)
         return self.filter_ratio
 
+    def mark_start_time(self, node_index):
+        node = self.nodes[node_index]
+        if node.api_valid_flag:
+            self.set_value_8(node, MARK_START_TIME, 0)
+
+    def mark_start_time_global(self):
+        for node in self.nodes:
+            self.mark_start_time(node.index)
+
+    def start_capture_enter_at_level(self, node_index):
+        node = self.nodes[node_index]
+        if node.cap_enter_at_flag is False and node.api_valid_flag:
+            node.cap_enter_at_total = 0
+            node.cap_enter_at_count = 0
+                   # set end time for capture of RSSI level:
+            node.cap_enter_at_millis = self.milliseconds() + CAP_ENTER_EXIT_AT_MILLIS
+            node.cap_enter_at_flag = True
+            return True
+        return False
+
+    def start_capture_exit_at_level(self, node_index):
+        node = self.nodes[node_index]
+        if node.cap_exit_at_flag is False and node.api_valid_flag:
+            node.cap_exit_at_total = 0
+            node.cap_exit_at_count = 0
+                   # set end time for capture of RSSI level:
+            node.cap_exit_at_millis = self.milliseconds() + CAP_ENTER_EXIT_AT_MILLIS
+            node.cap_exit_at_flag = True
+            return True
+        return False
+
     def intf_simulate_lap(self, node_index):
         node = self.nodes[node_index]
-        node.current_rssi = 11
-        node.trigger_rssi = 22
-        node.node_peak_rssi = 77
-        node.pass_peak_rssi = 44
-        node.loop_time = 55
         self.pass_record_callback(node, 100)
 
 def get_hardware_interface():

--- a/src/delta5interface/Node.py
+++ b/src/delta5interface/Node.py
@@ -4,28 +4,40 @@ class Node:
     '''Node class represents the arduino/rx pair.'''
     def __init__(self):
         self.api_level = 0
-        self.api_lvl5_flag = False
+        self.api_valid_flag = False
         self.frequency = 0
         self.current_rssi = 0
-        self.trigger_rssi = 0
         self.node_peak_rssi = 0
         self.pass_peak_rssi = 0
-        self.node_offs_adj = 0
+        self.pass_nadir_rssi = 0
         self.last_lap_id = -1
+        self.lap_ms_since_start = -1
         self.loop_time = 10
         self.crossing_flag = False
         self.debug_pass_count = 0
+        self.enter_at_level = 0
+        self.exit_at_level = 0
+        self.cap_enter_at_flag = False
+        self.cap_enter_at_total = 0
+        self.cap_enter_at_count = 0
+        self.cap_enter_at_millis = 0
+        self.cap_exit_at_flag = False
+        self.cap_exit_at_total = 0
+        self.cap_exit_at_count = 0
+        self.cap_exit_at_millis = 0
 
     def get_settings_json(self):
         return {
             'frequency': self.frequency,
             'current_rssi': self.current_rssi,
-            'trigger_rssi': self.trigger_rssi
+            'enter_at_level': self.enter_at_level,
+            'exit_at_level': self.exit_at_level
         }
 
     def get_heartbeat_json(self):
         return {
             'current_rssi': self.current_rssi,
-            'trigger_rssi': self.trigger_rssi,
-            'pass_peak_rssi': self.pass_peak_rssi
+            'node_peak_rssi': self.node_peak_rssi,
+            'pass_peak_rssi': self.pass_peak_rssi,
+            'pass_nadir_rssi': self.pass_nadir_rssi
         }

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -36,86 +36,88 @@
 #define i2cSlaveAddress (6 + (NODE_NUMBER * 2))
 
 // API level for read/write commands; increment when commands are modified
-#define NODE_API_LEVEL 5
+#define NODE_API_LEVEL 10
 
-const int slaveSelectPin = 10; // Setup data pins for rx5808 comms
+const int slaveSelectPin = 10;  // Setup data pins for rx5808 comms
 const int spiDataPin = 11;
 const int spiClockPin = 13;
 
 #define READ_ADDRESS 0x00
 #define READ_FREQUENCY 0x03
 #define READ_LAP_STATS 0x05
-#define READ_CALIBRATION_THRESHOLD 0x15
-#define READ_CALIBRATION_MODE 0x16
-#define READ_CALIBRATION_OFFSET 0x17
-#define READ_TRIGGER_THRESHOLD 0x18
-#define READ_FILTER_RATIO 0x19
+#define READ_FILTER_RATIO 0x20    // API_level>=10 uses 16-bit value
 #define READ_REVISION_CODE 0x22   // read NODE_API_LEVEL and verification value
 #define READ_NODE_RSSI_PEAK 0x23  // read 'state.nodeRssiPeak' value
+#define READ_ENTER_AT_LEVEL 0x31
+#define READ_EXIT_AT_LEVEL 0x32
+#define READ_TIME_MILLIS 0x33     // read current 'millis()' value
 
 #define WRITE_FREQUENCY 0x51
-#define WRITE_CALIBRATION_THRESHOLD 0x65
-#define WRITE_CALIBRATION_MODE 0x66
-#define WRITE_CALIBRATION_OFFSET 0x67
-#define WRITE_TRIGGER_THRESHOLD 0x68
-#define WRITE_FILTER_RATIO 0x69
+#define WRITE_FILTER_RATIO 0x70   // API_level>=10 uses 16-bit value
+#define WRITE_ENTER_AT_LEVEL 0x71
+#define WRITE_EXIT_AT_LEVEL 0x72
+#define MARK_START_TIME 0x77  // mark base time for returned lap-ms-since-start values
 
 #define FILTER_RATIO_DIVIDER 10000.0f
 
 #define EEPROM_ADRW_RXFREQ 0       //address for stored RX frequency value
-#define EEPROM_ADRW_RSSIPEAK 2     //address for stored 'nodeRssiPeak' value
-#define EEPROM_ADRW_CHECKWORD 4    //address for integrity-check value
-#define EEPROM_CHECK_VALUE 0x2645  //EEPROM integrity-check value
+#define EEPROM_ADRW_ENTERAT 2      //address for stored 'enterAtLevel'
+#define EEPROM_ADRW_EXITAT 4       //address for stored 'exitAtLevel'
+#define EEPROM_ADRW_CHECKWORD 6    //address for integrity-check value
+#define EEPROM_CHECK_VALUE 0x3526  //EEPROM integrity-check value
 
-struct {
-	uint16_t volatile vtxFreq = 5800;
-	// Subtracted from the peak rssi during a calibration pass to determine the trigger value
-	uint16_t volatile calibrationOffset = 8;
-	// Rssi must fall below trigger - settings.calibrationThreshold to end a calibration pass
-	uint16_t volatile calibrationThreshold = 95;
-	// Rssi must fall below trigger - settings.triggerThreshold to end a normal pass
-	uint16_t volatile triggerThreshold = 40;
-	uint8_t volatile filterRatio = 10;
-	float volatile filterRatioFloat = 0.0f;
+struct
+{
+    uint16_t volatile vtxFreq = 5800;
+    // lap pass begins when RSSI is at or above this level
+    uint16_t volatile enterAtLevel = 192;
+    // lap pass ends when RSSI goes below this level
+    uint16_t volatile exitAtLevel = 160;
+    uint16_t volatile filterRatio = 10;
+    float volatile filterRatioFloat = 0.0f;
 } settings;
 
-struct {
-	bool volatile calibrationMode = false;
-	// True when the quad is going through the gate
-	bool volatile crossing = false;
-	// Current unsmoothed rssi
-	uint16_t volatile rssiRaw = 0;
-	// Smoothed rssi value, needs to be a float for smoothing to work
-	float volatile rssiSmoothed = 0;
-	// int representation of the smoothed rssi value
-	uint16_t volatile rssi = 0;
-	// rssi value that will trigger a new pass
-	uint16_t volatile rssiTrigger;
-	// The peak raw rssi seen the current pass
-	uint16_t volatile rssiPeakRaw = 0;
-	// The peak smoothed rssi seen the current pass
-	uint16_t volatile rssiPeak = 0;
-	// The time of the peak raw rssi for the current pass
-	uint32_t volatile rssiPeakRawTimeStamp = 0;
-	// The peak smoothed rssi seen since the node frequency was set
-	uint16_t volatile nodeRssiPeak = 0;
+struct
+{
+    // True when the quad is going through the gate
+    bool volatile crossing = false;
+    // Current unsmoothed rssi
+    uint16_t volatile rssiRaw = 0;
+    // Smoothed rssi value, needs to be a float for smoothing to work
+    float volatile rssiSmoothed = 0;
+    // int representation of the smoothed rssi value
+    uint16_t volatile rssi = 0;
+    // peak raw rssi seen during current pass
+    uint16_t volatile passRssiPeakRaw = 0;
+    // peak smoothed rssi seen during current pass
+    uint16_t volatile passRssiPeak = 0;
+    // time of the peak raw rssi for the current pass
+    uint32_t volatile passRssiPeakRawTime = 0;
+    // lowest smoothed rssi seen since end of last pass
+    uint16_t volatile passRssiNadir = 999;
+    // peak smoothed rssi seen since the node frequency was set
+    uint16_t volatile nodeRssiPeak = 0;
     // Set true after initial WRITE_FREQUENCY command received
-	bool volatile rxFreqSetFlag = false;
+    bool volatile rxFreqSetFlag = false;
+    // base time for returned lap-ms-since-start values
+    uint32_t volatile raceStartTimeStamp = 0;
 
-	// variables to track the loop time
-	uint32_t volatile loopTime = 0;
-	uint32_t volatile lastLoopTimeStamp = 0;
+    // variables to track the loop time
+    uint32_t volatile loopTime = 0;
+    uint32_t volatile lastLoopTimeStamp = 0;
 } state;
 
-struct {
-	uint16_t volatile rssiPeakRaw;
-	uint16_t volatile rssiPeak;
-	uint32_t volatile timeStamp;
-	uint8_t volatile lap;
+struct
+{
+    uint16_t volatile rssiPeakRaw;
+    uint16_t volatile rssiPeak;
+    uint32_t volatile timeStamp;
+    uint16_t volatile rssiNadir;
+    uint8_t volatile lap;
 } lastPass;
 
-uint8_t volatile ioCommand; // I2C code to identify messages
-uint8_t volatile ioBuffer[32]; // Data array for sending over i2c, up to 32 bytes per message
+uint8_t volatile ioCommand;  // I2C code to identify messages
+uint8_t volatile ioBuffer[32];  // Data array for sending over i2c, up to 32 bytes per message
 int ioBufferSize = 0;
 int ioBufferIndex = 0;
 
@@ -124,467 +126,527 @@ int ioBufferIndex = 0;
 #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 
 // Initialize program
-void setup() {
-	Serial.begin(115200); // Start serial for output/debugging
+void setup()
+{
+    Serial.begin(115200);  // Start serial for output/debugging
 
-	pinMode (slaveSelectPin, OUTPUT); // RX5808 comms
-	pinMode (spiDataPin, OUTPUT);
-	pinMode (spiClockPin, OUTPUT);
-	digitalWrite(slaveSelectPin, HIGH);
+    pinMode(slaveSelectPin, OUTPUT);  // RX5808 comms
+    pinMode(spiDataPin, OUTPUT);
+    pinMode(spiClockPin, OUTPUT);
+    digitalWrite(slaveSelectPin, HIGH);
 
-	while (!Serial) {
-	}; // Wait for the Serial port to initialise
-	Serial.print("Ready: ");
-	Serial.println(i2cSlaveAddress);
+    while (!Serial)
+    {
+    };  // Wait for the Serial port to initialise
+    Serial.print("Ready: ");
+    Serial.println(i2cSlaveAddress);
 
-	Wire.begin(i2cSlaveAddress); // I2C slave address setup
-	Wire.onReceive(i2cReceive); // Trigger 'i2cReceive' function on incoming data
-	Wire.onRequest(i2cTransmit); // Trigger 'i2cTransmit' function for outgoing data, on master request
+    Wire.begin(i2cSlaveAddress);  // I2C slave address setup
+    Wire.onReceive(i2cReceive);  // Trigger 'i2cReceive' function on incoming data
+    Wire.onRequest(i2cTransmit);  // Trigger 'i2cTransmit' function for outgoing data, on master request
 
-	// set ADC prescaler to 16 to speedup ADC readings
-    sbi(ADCSRA,ADPS2);
-    cbi(ADCSRA,ADPS1);
-    cbi(ADCSRA,ADPS0);
+    // set ADC prescaler to 16 to speedup ADC readings
+    sbi(ADCSRA, ADPS2);
+    cbi(ADCSRA, ADPS1);
+    cbi(ADCSRA, ADPS0);
 
-	// Initialize defaults
-	settings.filterRatioFloat = settings.filterRatio / FILTER_RATIO_DIVIDER;
-	state.rssi = 0;
-	state.rssiTrigger = 0;
-	lastPass.rssiPeakRaw = 0;
-	lastPass.rssiPeak = 0;
-	lastPass.lap = 0;
-	lastPass.timeStamp = 0;
+    // Initialize defaults
+    settings.filterRatioFloat = settings.filterRatio / FILTER_RATIO_DIVIDER;
+    state.rssi = 0;
+    lastPass.rssiPeakRaw = 0;
+    lastPass.rssiPeak = 0;
+    lastPass.lap = 0;
+    lastPass.timeStamp = 0;
 
     // if EEPROM-check value matches then read stored values
-    if (readWordFromEeprom(EEPROM_ADRW_CHECKWORD) == EEPROM_CHECK_VALUE) {
+    if (readWordFromEeprom(EEPROM_ADRW_CHECKWORD) == EEPROM_CHECK_VALUE)
+    {
         settings.vtxFreq = readWordFromEeprom(EEPROM_ADRW_RXFREQ);
-        state.nodeRssiPeak = readWordFromEeprom(EEPROM_ADRW_RSSIPEAK);
+        settings.enterAtLevel = readWordFromEeprom(EEPROM_ADRW_ENTERAT);
+        settings.exitAtLevel = readWordFromEeprom(EEPROM_ADRW_EXITAT);
     }
-    else {    // if no match then initialize EEPROM values
+    else
+    {    // if no match then initialize EEPROM values
         writeWordToEeprom(EEPROM_ADRW_RXFREQ, settings.vtxFreq);
-        writeWordToEeprom(EEPROM_ADRW_RSSIPEAK, 0);
+        writeWordToEeprom(EEPROM_ADRW_ENTERAT, settings.enterAtLevel);
+        writeWordToEeprom(EEPROM_ADRW_EXITAT, settings.exitAtLevel);
         writeWordToEeprom(EEPROM_ADRW_CHECKWORD, EEPROM_CHECK_VALUE);
     }
 
-	setRxModule(settings.vtxFreq); // Setup rx module to default frequency
+    setRxModule(settings.vtxFreq);  // Setup rx module to default frequency
 }
 
 // Functions for the rx5808 module
-void SERIAL_SENDBIT1() {
-	digitalWrite(spiClockPin, LOW);
-	delayMicroseconds(300);
-	digitalWrite(spiDataPin, HIGH);
-	delayMicroseconds(300);
-	digitalWrite(spiClockPin, HIGH);
-	delayMicroseconds(300);
-	digitalWrite(spiClockPin, LOW);
-	delayMicroseconds(300);
+
+void SERIAL_SENDBIT1()
+{
+    digitalWrite(spiClockPin, LOW);
+    delayMicroseconds(300);
+    digitalWrite(spiDataPin, HIGH);
+    delayMicroseconds(300);
+    digitalWrite(spiClockPin, HIGH);
+    delayMicroseconds(300);
+    digitalWrite(spiClockPin, LOW);
+    delayMicroseconds(300);
 }
-void SERIAL_SENDBIT0() {
-	digitalWrite(spiClockPin, LOW);
-	delayMicroseconds(300);
-	digitalWrite(spiDataPin, LOW);
-	delayMicroseconds(300);
-	digitalWrite(spiClockPin, HIGH);
-	delayMicroseconds(300);
-	digitalWrite(spiClockPin, LOW);
-	delayMicroseconds(300);
+
+void SERIAL_SENDBIT0()
+{
+    digitalWrite(spiClockPin, LOW);
+    delayMicroseconds(300);
+    digitalWrite(spiDataPin, LOW);
+    delayMicroseconds(300);
+    digitalWrite(spiClockPin, HIGH);
+    delayMicroseconds(300);
+    digitalWrite(spiClockPin, LOW);
+    delayMicroseconds(300);
 }
-void SERIAL_ENABLE_LOW() {
-	delayMicroseconds(100);
-	digitalWrite(slaveSelectPin,LOW);
-	delayMicroseconds(100);
+
+void SERIAL_ENABLE_LOW()
+{
+    delayMicroseconds(100);
+    digitalWrite(slaveSelectPin, LOW);
+    delayMicroseconds(100);
 }
-void SERIAL_ENABLE_HIGH() {
-	delayMicroseconds(100);
-	digitalWrite(slaveSelectPin,HIGH);
-	delayMicroseconds(100);
+
+void SERIAL_ENABLE_HIGH()
+{
+    delayMicroseconds(100);
+    digitalWrite(slaveSelectPin, HIGH);
+    delayMicroseconds(100);
 }
 
 // Calculate rx5808 register hex value for given frequency in MHz
-uint16_t freqMhzToRegVal(uint16_t freqInMhz) {
-  uint16_t tf, N, A;
-  tf = (freqInMhz - 479) / 2;
-  N = tf / 32;
-  A = tf % 32;
-  return (N<<7) + A;
+uint16_t freqMhzToRegVal(uint16_t freqInMhz)
+{
+    uint16_t tf, N, A;
+    tf = (freqInMhz - 479) / 2;
+    N = tf / 32;
+    A = tf % 32;
+    return (N << 7) + A;
 }
 
 // Set the frequency given on the rx5808 module
-void setRxModule(int frequency) {
-	uint8_t i; // Used in the for loops
+void setRxModule(int frequency)
+{
+    uint8_t i;  // Used in the for loops
 
-	// Get the hex value to send to the rx module
-	uint16_t vtxHex = freqMhzToRegVal(frequency);
+    // Get the hex value to send to the rx module
+    uint16_t vtxHex = freqMhzToRegVal(frequency);
 
-	// bit bash out 25 bits of data / Order: A0-3, !R/W, D0-D19 / A0=0, A1=0, A2=0, A3=1, RW=0, D0-19=0
-	SERIAL_ENABLE_HIGH();
-	delay(2);
-	SERIAL_ENABLE_LOW();
-	SERIAL_SENDBIT0();
-	SERIAL_SENDBIT0();
-	SERIAL_SENDBIT0();
-	SERIAL_SENDBIT1();
-	SERIAL_SENDBIT0();
+    // bit bash out 25 bits of data / Order: A0-3, !R/W, D0-D19 / A0=0, A1=0, A2=0, A3=1, RW=0, D0-19=0
+    SERIAL_ENABLE_HIGH();
+    delay(2);
+    SERIAL_ENABLE_LOW();
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT1();
+    SERIAL_SENDBIT0();
 
-	for (i = 20; i > 0; i--) SERIAL_SENDBIT0(); // Remaining zeros
+    for (i = 20; i > 0; i--)
+        SERIAL_SENDBIT0();  // Remaining zeros
 
-	SERIAL_ENABLE_HIGH(); // Clock the data in
-	delay(2);
-	SERIAL_ENABLE_LOW();
+    SERIAL_ENABLE_HIGH();  // Clock the data in
+    delay(2);
+    SERIAL_ENABLE_LOW();
 
-	// Second is the channel data from the lookup table, 20 bytes of register data are sent, but the
-	// MSB 4 bits are zeros register address = 0x1, write, data0-15=vtxHex data15-19=0x0
-	SERIAL_ENABLE_HIGH();
-	SERIAL_ENABLE_LOW();
+    // Second is the channel data from the lookup table, 20 bytes of register data are sent, but the
+    // MSB 4 bits are zeros register address = 0x1, write, data0-15=vtxHex data15-19=0x0
+    SERIAL_ENABLE_HIGH();
+    SERIAL_ENABLE_LOW();
 
-	SERIAL_SENDBIT1(); // Register 0x1
-	SERIAL_SENDBIT0();
-	SERIAL_SENDBIT0();
-	SERIAL_SENDBIT0();
+    SERIAL_SENDBIT1();  // Register 0x1
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT0();
+    SERIAL_SENDBIT0();
 
-	SERIAL_SENDBIT1(); // Write to register
+    SERIAL_SENDBIT1();  // Write to register
 
-	// D0-D15, note: loop runs backwards as more efficent on AVR
-	for (i = 16; i > 0; i--) {
-		if (vtxHex & 0x1) { // Is bit high or low?
-			SERIAL_SENDBIT1();
-		}
-		else {
-			SERIAL_SENDBIT0();
-		}
-		vtxHex >>= 1; // Shift bits along to check the next one
-	}
+    // D0-D15, note: loop runs backwards as more efficent on AVR
+    for (i = 16; i > 0; i--)
+    {
+        if (vtxHex & 0x1)
+        {  // Is bit high or low?
+            SERIAL_SENDBIT1();
+        }
+        else
+        {
+            SERIAL_SENDBIT0();
+        }
+        vtxHex >>= 1;  // Shift bits along to check the next one
+    }
 
-	for (i = 4; i > 0; i--) // Remaining D16-D19
-		SERIAL_SENDBIT0();
+    for (i = 4; i > 0; i--)  // Remaining D16-D19
+        SERIAL_SENDBIT0();
 
-	SERIAL_ENABLE_HIGH(); // Finished clocking data in
-	delay(2);
+    SERIAL_ENABLE_HIGH();  // Finished clocking data in
+    delay(2);
 
-	digitalWrite(slaveSelectPin,LOW);
-	digitalWrite(spiClockPin, LOW);
-	digitalWrite(spiDataPin, LOW);
+    digitalWrite(slaveSelectPin, LOW);
+    digitalWrite(spiClockPin, LOW);
+    digitalWrite(spiDataPin, LOW);
 }
 
-
 // Read the RSSI value for the current channel
-int rssiRead() {
-	return analogRead(0);
+int rssiRead()
+{
+    return analogRead(0);
 }
 
 // Main loop
-void loop() {
-	//delay(250);
+void loop()
+{
+    //delay(250);
 
-	// Calculate the time it takes to run the main loop
-	uint32_t lastLoopTimeStamp = state.lastLoopTimeStamp;
-	state.lastLoopTimeStamp = micros();
-	state.loopTime = state.lastLoopTimeStamp - lastLoopTimeStamp;
+    // Calculate the time it takes to run the main loop
+    uint32_t lastLoopTimeStamp = state.lastLoopTimeStamp;
+    state.lastLoopTimeStamp = micros();
+    state.loopTime = state.lastLoopTimeStamp - lastLoopTimeStamp;
 
-	state.rssiRaw = rssiRead();
-	state.rssiSmoothed = (settings.filterRatioFloat * (float)state.rssiRaw) + ((1.0f-settings.filterRatioFloat) * state.rssiSmoothed);
-	state.rssi = (int)state.rssiSmoothed;
+    state.rssiRaw = rssiRead();
+    state.rssiSmoothed = (settings.filterRatioFloat * (float) state.rssiRaw)
+            + ((1.0f - settings.filterRatioFloat) * state.rssiSmoothed);
+    state.rssi = (int) state.rssiSmoothed;
+    
+    if (state.rxFreqSetFlag)
+    {  //don't start operations until after first WRITE_FREQUENCY command is received
+        
+        // Keep track of peak (smoothed) rssi
+        if (state.rssi > state.nodeRssiPeak)
+        {
+            state.nodeRssiPeak = state.rssi;
+            Serial.print("New nodeRssiPeak = ");
+            Serial.println(state.nodeRssiPeak);
+        }
 
-	// Keep track of peak (smoothed) rssi; set trigger as offset of peak
-    //  (don't start tracking until after a WRITE_FREQUENCY command received)
-	if (state.rssi > state.nodeRssiPeak && state.rxFreqSetFlag) {
-		state.nodeRssiPeak = state.rssi;
-		state.rssiTrigger = state.nodeRssiPeak - settings.calibrationOffset;
-        writeWordToEeprom(EEPROM_ADRW_RSSIPEAK, state.nodeRssiPeak);  // persist value
-		Serial.print("New nodeRssiPeak = ");
-		Serial.println(state.nodeRssiPeak);
-	}
+        if ((!state.crossing) && state.rssi >= settings.enterAtLevel)
+        {
+            state.crossing = true;  // quad is going through the gate (lap pass starting)
+            Serial.println("Crossing = True");
+        }
 
-	if (state.rssiTrigger > 0) {
-		if (!state.crossing && state.rssi > state.rssiTrigger) {
-			state.crossing = true; // Quad is going through the gate
-			Serial.println("Crossing = True");
-		}
+        // Find the peak rssi and the time it occured during a crossing event
+        // Use the raw value to account for the delay in smoothing.
+        if (state.rssiRaw > state.passRssiPeakRaw)
+        {
+            state.passRssiPeakRaw = state.rssiRaw;
+            state.passRssiPeakRawTime = millis();
+        }
 
-		// Find the peak rssi and the time it occured during a crossing event
-		// Use the raw value to account for the delay in smoothing.
-		if (state.rssiRaw > state.rssiPeakRaw) {
-			state.rssiPeakRaw = state.rssiRaw;
-			state.rssiPeakRawTimeStamp = millis();
-		}
+        // track lowest smoothed rssi seen since end of last pass
+        if (state.rssi < state.passRssiNadir)
+            state.passRssiNadir = state.rssi;
+        
+        if (state.crossing)
+        {  //lap pass is in progress
+            
+            // track RSSI peak for current lap pass
+            if (state.rssi > state.passRssiPeak)
+                state.passRssiPeak = state.rssi;
 
-		if (state.crossing) {
+            // see if quad has left the gate
+            if (state.rssi < settings.exitAtLevel)
+            {
+                Serial.println("Crossing = False");
+                
+                // save values for lap pass
+                lastPass.rssiPeakRaw = state.passRssiPeakRaw;
+                lastPass.rssiPeak = state.passRssiPeak;
+                lastPass.timeStamp = state.passRssiPeakRawTime;
+                lastPass.rssiNadir = state.passRssiNadir;
+                lastPass.lap = lastPass.lap + 1;
 
-			state.rssiPeak = max(state.rssiPeak, state.rssi);
-
-			// Make sure the threshold does not put the trigger below 0 RSSI
-			// See if we have left the gate
-			if ((state.rssiTrigger > settings.triggerThreshold) &&
-				(state.rssi < (state.rssiTrigger - settings.triggerThreshold))) {
-				Serial.println("Crossing = False");
-				lastPass.rssiPeakRaw = state.rssiPeakRaw;
-				lastPass.rssiPeak = state.rssiPeak;
-				lastPass.timeStamp = state.rssiPeakRawTimeStamp;
-				lastPass.lap = lastPass.lap + 1;
-
-				state.crossing = false;
-				state.calibrationMode = false;
-				state.rssiPeakRaw = 0;
-				state.rssiPeak = 0;
-			}
-		}
-	}
+                // reset lap-pass variables
+                state.crossing = false;
+                state.passRssiPeakRaw = 0;
+                state.passRssiPeak = 0;
+                state.passRssiNadir = 999;
+            }
+        }
+    }
 }
-
 
 // Function called by twi interrupt service when master sends information to the slave
 // or when master sets up a specific read request
-void i2cReceive(int byteCount) { // Number of bytes in rx buffer
-	// If byteCount is zero, the master only checked for presence of the slave device, no response necessary
-	if (byteCount == 0) {
-		Serial.println("Error: no bytes for a receive?");
-		return;
-	}
+void i2cReceive(int byteCount)
+{  // Number of bytes in rx buffer
+   // If byteCount is zero, the master only checked for presence of the slave device, no response necessary
+    if (byteCount == 0)
+    {
+        Serial.println("Error: no bytes for a receive?");
+        return;
+    }
 
-	if (byteCount != Wire.available()) {
-		Serial.println("Error: rx byte count and wire available don't agree");
-	}
+    if (byteCount != Wire.available())
+    {
+        Serial.println("Error: rx byte count and wire available don't agree");
+    }
 
-	ioCommand = Wire.read(); // The first byte sent is a command byte
+    ioCommand = Wire.read();  // The first byte sent is a command byte
 
-	if (ioCommand > 0x50) { // Commands > 0x50 are writes TO this slave
-		i2cHandleRx(ioCommand);
-	}
-	else { // Otherwise this is a request FROM this device
-		if (Wire.available()) { // There shouldn't be any data present on the line for a read request
-			Serial.print("Error: Wire.available() on a read request.");
-			Serial.println(ioCommand, HEX);
-			while(Wire.available()) {
-				Wire.read();
-			}
-		}
-	}
+    if (ioCommand > 0x50)
+    {  // Commands > 0x50 are writes TO this slave
+        i2cHandleRx(ioCommand);
+    }
+    else
+    {  // Otherwise this is a request FROM this device
+        if (Wire.available())
+        {  // There shouldn't be any data present on the line for a read request
+            Serial.print("Error: Wire.available() on a read request.");
+            Serial.println(ioCommand, HEX);
+            while (Wire.available())
+            {
+                Wire.read();
+            }
+        }
+    }
 }
 
-bool readAndValidateIoBuffer(byte command, int expectedSize) {
-	uint8_t checksum = 0;
-	ioBufferSize = 0;
-	ioBufferIndex = 0;
+bool readAndValidateIoBuffer(byte command, int expectedSize)
+{
+    uint8_t checksum = 0;
+    ioBufferSize = 0;
+    ioBufferIndex = 0;
 
-	if (expectedSize == 0) {
-		Serial.println("No Expected Size");
-		return true;
-	}
+    if (expectedSize == 0)
+    {
+        Serial.println("No Expected Size");
+        return true;
+    }
 
-	if (!Wire.available()) {
-		Serial.println("Nothing Avialable");
-		return false;
-	}
+    if (!Wire.available())
+    {
+        Serial.println("Nothing Avialable");
+        return false;
+    }
 
-	while(Wire.available()) {
-		ioBuffer[ioBufferSize++] = Wire.read();
-		if (expectedSize + 1 < ioBufferSize) {
-			checksum += ioBuffer[ioBufferSize-1];
-		}
-	}
+    while (Wire.available())
+    {
+        ioBuffer[ioBufferSize++] = Wire.read();
+        if (expectedSize + 1 < ioBufferSize)
+        {
+            checksum += ioBuffer[ioBufferSize - 1];
+        }
+    }
 
-	if (checksum != ioBuffer[ioBufferSize-1] ||
-		ioBufferSize-2 != expectedSize) {
-		Serial.println("invalid checksum");
-		Serial.println(checksum);
-		Serial.println(ioBuffer[ioBufferSize-1]);
-		Serial.println(ioBufferSize-2);
-		Serial.println(expectedSize);
-		return false;
-	}
+    if (checksum != ioBuffer[ioBufferSize - 1]
+            || ioBufferSize - 2 != expectedSize)
+    {
+        Serial.println("invalid checksum");
+        Serial.println(checksum);
+        Serial.println(ioBuffer[ioBufferSize - 1]);
+        Serial.println(ioBufferSize - 2);
+        Serial.println(expectedSize);
+        return false;
+    }
 
-	if (command != ioBuffer[ioBufferSize-2]) {
-		Serial.println("command does not match");
-		return false;
-	}
-	return true;
+    if (command != ioBuffer[ioBufferSize - 2])
+    {
+        Serial.println("command does not match");
+        return false;
+    }
+    return true;
 }
 
-uint8_t ioBufferRead8() {
-	return ioBuffer[ioBufferIndex++];
+uint8_t ioBufferRead8()
+{
+    return ioBuffer[ioBufferIndex++];
 }
 
-uint16_t ioBufferRead16() {
-	uint16_t result;
-	result = ioBuffer[ioBufferIndex++];
-	result = (result << 8) | ioBuffer[ioBufferIndex++];
-	return result;
+uint16_t ioBufferRead16()
+{
+    uint16_t result;
+    result = ioBuffer[ioBufferIndex++];
+    result = (result << 8) | ioBuffer[ioBufferIndex++];
+    return result;
 }
 
-void ioBufferWrite8(uint8_t data) {
-	ioBuffer[ioBufferSize++] = data;
+void ioBufferWrite8(uint8_t data)
+{
+    ioBuffer[ioBufferSize++] = data;
 }
 
-void ioBufferWrite16(uint16_t data) {
-	ioBuffer[ioBufferSize++] = (uint16_t)(data >> 8);
-	ioBuffer[ioBufferSize++] = (uint16_t)(data & 0xFF);
+void ioBufferWrite16(uint16_t data)
+{
+    ioBuffer[ioBufferSize++] = (uint16_t)(data >> 8);
+    ioBuffer[ioBufferSize++] = (uint16_t)(data & 0xFF);
 }
 
-void ioBufferWrite32(uint32_t data) {
-	ioBuffer[ioBufferSize++] = (uint16_t)(data >> 24);
-	ioBuffer[ioBufferSize++] = (uint16_t)(data >> 16);
-	ioBuffer[ioBufferSize++] = (uint16_t)(data >> 8);
-	ioBuffer[ioBufferSize++] = (uint16_t)(data & 0xFF);
+void ioBufferWrite32(uint32_t data)
+{
+    ioBuffer[ioBufferSize++] = (uint16_t)(data >> 24);
+    ioBuffer[ioBufferSize++] = (uint16_t)(data >> 16);
+    ioBuffer[ioBufferSize++] = (uint16_t)(data >> 8);
+    ioBuffer[ioBufferSize++] = (uint16_t)(data & 0xFF);
 }
 
-void ioBufferWriteChecksum() {
-	uint8_t checksum = 0;
-	for (int i = 0; i < ioBufferSize ; i++) {
-		checksum += ioBuffer[i];
-	}
+void ioBufferWriteChecksum()
+{
+    uint8_t checksum = 0;
+    for (int i = 0; i < ioBufferSize; i++)
+    {
+        checksum += ioBuffer[i];
+    }
 
-	ioBufferWrite8(checksum);
+    ioBufferWrite8(checksum);
 }
 
 // Function called by i2cReceive for writes TO this device, the I2C Master has sent data
 // using one of the SMBus write commands, if the MSB of 'command' is 0, master is sending only
 // Returns the number of bytes read, or FF if unrecognised command or mismatch between
 // data expected and received
-byte i2cHandleRx(byte command) { // The first byte sent by the I2C master is the command
-	bool success = false;
-    uint16_t oldVtxFreq;
+byte i2cHandleRx(byte command)
+{  // The first byte sent by the I2C master is the command
+    bool success = false;
+    uint16_t u16val;
 
-	switch (command) {
-		case WRITE_FREQUENCY:
-			if (readAndValidateIoBuffer(0x51, 2)) {
-                oldVtxFreq = settings.vtxFreq;
-				settings.vtxFreq = ioBufferRead16();
-				setRxModule(settings.vtxFreq); // Shouldn't do this in Interrupt Service Routine
-				success = true;
+    switch (command)
+    {
+        case WRITE_FREQUENCY:
+            if (readAndValidateIoBuffer(0x51, 2))
+            {
+                u16val = settings.vtxFreq;
+                settings.vtxFreq = ioBufferRead16();
+                setRxModule(settings.vtxFreq);  // Shouldn't do this in Interrupt Service Routine
+                success = true;
                 state.rxFreqSetFlag = true;
-				Serial.print("Set RX freq = ");
-				Serial.println(settings.vtxFreq);
-                if (settings.vtxFreq != oldVtxFreq) {  // if RX frequency changed
-			        writeWordToEeprom(EEPROM_ADRW_RXFREQ, settings.vtxFreq);
-					state.nodeRssiPeak = 0;  // restart rssi peak tracking for node
-	                writeWordToEeprom(EEPROM_ADRW_RSSIPEAK, 0);  // persist value
-					Serial.println("Set nodeRssiPeak = 0");
+                Serial.print("Set RX freq = ");
+                Serial.println(settings.vtxFreq);
+                if (settings.vtxFreq != u16val)
+                {  // if RX frequency changed
+                    writeWordToEeprom(EEPROM_ADRW_RXFREQ, settings.vtxFreq);
+                    state.nodeRssiPeak = 0;  // restart rssi peak tracking for node
+                    Serial.println("Set nodeRssiPeak = 0");
                 }
-			}
-			break;
-		case WRITE_CALIBRATION_THRESHOLD:
-                        // no longer using this; but keep cmd for backward compatibility
-			if (readAndValidateIoBuffer(WRITE_CALIBRATION_THRESHOLD, 2)) {
-				settings.calibrationThreshold = ioBufferRead16();
-				success = true;
-			}
-			break;
-		case WRITE_CALIBRATION_MODE:
-                   // no longer using this; but keep cmd for backward compatibility
-			if (readAndValidateIoBuffer(WRITE_CALIBRATION_MODE, 1)) {
-				state.calibrationMode = ioBufferRead8();
-				state.rssiTrigger = state.nodeRssiPeak - settings.calibrationOffset;
-				lastPass.rssiPeakRaw = 0;
-				lastPass.rssiPeak = 0;
-				state.rssiPeakRaw = 0;
-				state.rssiPeakRawTimeStamp = 0;
-				success = true;
-			}
-			break;
-		case WRITE_CALIBRATION_OFFSET:
-			if (readAndValidateIoBuffer(WRITE_CALIBRATION_OFFSET, 2)) {
-				settings.calibrationOffset = ioBufferRead16();
-				success = true;
-                        // keep the trigger value updated:
-                state.rssiTrigger = state.nodeRssiPeak - settings.calibrationOffset;
-			}
-			break;
-		case WRITE_TRIGGER_THRESHOLD:
-			if (readAndValidateIoBuffer(WRITE_TRIGGER_THRESHOLD, 2)) {
-				settings.triggerThreshold = ioBufferRead16();
-				success = true;
-			}
-			break;
-		case WRITE_FILTER_RATIO:
-			if (readAndValidateIoBuffer(WRITE_FILTER_RATIO, 1)) {
-				settings.filterRatio = ioBufferRead8();
-				settings.filterRatioFloat =  settings.filterRatio / FILTER_RATIO_DIVIDER;
-				success = true;
-			}
-			break;
-	}
+            }
+            break;
 
-	ioCommand = 0; // Clear previous command
+        case WRITE_ENTER_AT_LEVEL:  // lap pass begins when RSSI is at or above this level
+            if (readAndValidateIoBuffer(WRITE_ENTER_AT_LEVEL, 2))
+            {
+                settings.enterAtLevel = ioBufferRead16();
+                writeWordToEeprom(EEPROM_ADRW_ENTERAT, settings.enterAtLevel);
+                success = true;
+            }
+            break;
 
-	if (!success) { // Set control to rxFault if 0xFF result
-		 Serial.print("RX Fault command: ");
-		 Serial.println(command, HEX);
-	}
-	return success;
+        case WRITE_EXIT_AT_LEVEL:  // lap pass ends when RSSI goes below this level
+            if (readAndValidateIoBuffer(WRITE_EXIT_AT_LEVEL, 2))
+            {
+                settings.exitAtLevel = ioBufferRead16();
+                writeWordToEeprom(EEPROM_ADRW_EXITAT, settings.exitAtLevel);
+                success = true;
+            }
+            break;
+
+        case WRITE_FILTER_RATIO:
+            if (readAndValidateIoBuffer(WRITE_FILTER_RATIO, 2))
+            {
+                u16val = ioBufferRead16();
+                if (u16val >= 1 && u16val <= FILTER_RATIO_DIVIDER)
+                {
+                    settings.filterRatio = u16val;
+                    settings.filterRatioFloat = settings.filterRatio / FILTER_RATIO_DIVIDER;
+                    success = true;
+                }
+            }
+            break;
+
+        case MARK_START_TIME:  // mark base time for returned lap-ms-since-start values
+            state.raceStartTimeStamp = millis();
+            if (readAndValidateIoBuffer(MARK_START_TIME, 1))  // read byte value (not used)
+                success = true;
+            break;
+    }
+
+    ioCommand = 0;  // Clear previous command
+
+    if (!success)
+    {  // Set control to rxFault if 0xFF result
+        Serial.print("RX Fault command: ");
+        Serial.println(command, HEX);
+    }
+    return success;
 }
 
 // Function called by twi interrupt service when the Master wants to get data from the Slave
 // No parameters and no returns
 // A transmit buffer (ioBuffer) is populated with the data before sending.
-void i2cTransmit() {
-	ioBufferSize = 0;
+void i2cTransmit()
+{
+    ioBufferSize = 0;
 
-	switch (ioCommand) {
-		case READ_ADDRESS:
-			ioBufferWrite8(i2cSlaveAddress);
-			break;
-		case READ_FREQUENCY:
-			ioBufferWrite16(settings.vtxFreq);
-			break;
-		case READ_LAP_STATS:
-			ioBufferWrite8(lastPass.lap);
-			ioBufferWrite32(millis() - lastPass.timeStamp);
-			ioBufferWrite16(state.rssi);
-			ioBufferWrite16(state.rssiTrigger);
-			// ioBufferWrite16(lastPass.rssiPeakRaw);
-			ioBufferWrite16(state.nodeRssiPeak);  // as of API 5 return 'nodeRssiPeak' here
-			ioBufferWrite16(lastPass.rssiPeak);
-			ioBufferWrite32(state.loopTime);
-			ioBufferWrite8(state.crossing ? (uint8_t)1 : (uint8_t)0);  // as of API 5 return 'crossing' status
-			break;
-		case READ_CALIBRATION_THRESHOLD:
-                   // no longer using this; but keep cmd for backward compatibility
-			ioBufferWrite16(settings.calibrationThreshold);
-			break;
-		case READ_CALIBRATION_MODE:
-                   // no longer using this; but keep cmd for backward compatibility
-			ioBufferWrite8(state.calibrationMode);
-			break;
-		case READ_CALIBRATION_OFFSET:
-			ioBufferWrite16(settings.calibrationOffset);
-			break;
-		case READ_TRIGGER_THRESHOLD:
-			ioBufferWrite16(settings.triggerThreshold);
-			break;
-		case READ_FILTER_RATIO:
-			ioBufferWrite8(settings.filterRatio);
-			break;
-		case READ_REVISION_CODE:  // reply with NODE_API_LEVEL and verification value
-			ioBufferWrite16((0x25 << 8) + NODE_API_LEVEL);
-			break;
-		case READ_NODE_RSSI_PEAK:
-			ioBufferWrite16(state.nodeRssiPeak);
-			break;
-		default: // If an invalid command is sent, write nothing back, master must react
-			Serial.print("TX Fault command: ");
-			Serial.println(ioCommand, HEX);
-	}
+    switch (ioCommand)
+    {
+        case READ_ADDRESS:
+            ioBufferWrite8(i2cSlaveAddress);
+            break;
 
-	ioCommand = 0; // Clear previous command
+        case READ_FREQUENCY:
+            ioBufferWrite16(settings.vtxFreq);
+            break;
 
-	if (ioBufferSize > 0) { // If there is pending data, send it
-		ioBufferWriteChecksum();
-		Wire.write((byte *)&ioBuffer, ioBufferSize);
-	}
+        case READ_LAP_STATS:
+            ioBufferWrite8(lastPass.lap);
+            ioBufferWrite32(lastPass.timeStamp - state.raceStartTimeStamp);  // lap ms-since-start
+            ioBufferWrite16(state.rssi);
+            ioBufferWrite16(state.nodeRssiPeak);
+            ioBufferWrite16(lastPass.rssiPeak);  // RSSI peak for last lap pass
+            ioBufferWrite32(state.loopTime);
+            ioBufferWrite8(state.crossing ? (uint8_t) 1 : (uint8_t) 0);  // 'crossing' status
+            ioBufferWrite16(lastPass.rssiNadir);  // lowest rssi since end of last pass
+            break;
+
+        case READ_ENTER_AT_LEVEL:  // lap pass begins when RSSI is at or above this level
+            ioBufferWrite16(settings.enterAtLevel);
+            break;
+
+        case READ_EXIT_AT_LEVEL:  // lap pass ends when RSSI goes below this level
+            ioBufferWrite16(settings.exitAtLevel);
+            break;
+
+        case READ_FILTER_RATIO:
+            ioBufferWrite16(settings.filterRatio);
+            break;
+
+        case READ_REVISION_CODE:  // reply with NODE_API_LEVEL and verification value
+            ioBufferWrite16((0x25 << 8) + NODE_API_LEVEL);
+            break;
+
+        case READ_NODE_RSSI_PEAK:
+            ioBufferWrite16(state.nodeRssiPeak);
+            break;
+
+        case READ_TIME_MILLIS:
+            ioBufferWrite32(millis());
+            break;
+
+        default:  // If an invalid command is sent, write nothing back, master must react
+            Serial.print("TX Fault command: ");
+            Serial.println(ioCommand, HEX);
+    }
+
+    ioCommand = 0;  // Clear previous command
+
+    if (ioBufferSize > 0)
+    {  // If there is pending data, send it
+        ioBufferWriteChecksum();
+        Wire.write((byte *) &ioBuffer, ioBufferSize);
+    }
 }
 
 //Writes 2-byte word to EEPROM at address.
 void writeWordToEeprom(int addr, uint16_t val)
 {
-  EEPROM.write(addr,lowByte(val));
-  EEPROM.write(addr+1,highByte(val));
+    EEPROM.write(addr, lowByte(val));
+    EEPROM.write(addr + 1, highByte(val));
 }
 
 //Reads 2-byte word at address from EEPROM.
 uint16_t readWordFromEeprom(int addr)
 {
-  const uint8_t lb = EEPROM.read(addr);
-  const uint8_t hb = EEPROM.read(addr+1);
-  return (((uint16_t)hb) << 8) + lb;
+    const uint8_t lb = EEPROM.read(addr);
+    const uint8_t hb = EEPROM.read(addr + 1);
+    return (((uint16_t) hb) << 8) + lb;
 }

--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -555,6 +555,8 @@ byte i2cHandleRx(byte command)
 
         case MARK_START_TIME:  // mark base time for returned lap-ms-since-start values
             state.raceStartTimeStamp = millis();
+                   // make sure there's no lingering previous timestamp:
+            lastPass.timeStamp = state.raceStartTimeStamp;
             if (readAndValidateIoBuffer(MARK_START_TIME, 1))  // read byte value (not used)
                 success = true;
             break;

--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -930,7 +930,7 @@ def on_simulate_lap(data):
     '''Simulates a lap (for debug testing).'''
     node_index = data['node']
     server_log('Simulated lap: Node {0}'.format(node_index+1))
-    INTERFACE.intf_simulate_lap(node_index)
+    INTERFACE.intf_simulate_lap(node_index, ms_from_race_start())
 
 @SOCKET_IO.on('LED_solid')
 def on_LED_solid(data):

--- a/src/delta5server/static/d5rt.js
+++ b/src/delta5server/static/d5rt.js
@@ -374,6 +374,7 @@ var freq = {
 		U6: 5420,
 		U7: 5438,
 		U8: 5456,
+		U9: 5985,
 		'N/A': 'n/a'
 	},
 	findByFreq: function(frequency) {

--- a/src/delta5server/templates/correction.html
+++ b/src/delta5server/templates/correction.html
@@ -392,7 +392,7 @@
 
 					<div class="compact-field">
 						<label for="s_channel_{{ node }}">Frequency</label>
-						<input type="number" id="s_channel_{{ node }}" class="set_frequency" data-node="{{ node }}" min="5300" max="6001">
+						<input type="number" id="s_channel_{{ node }}" class="set_frequency" data-node="{{ node }}" min="5000" max="6001">
 					</div>
 
 					<div class="compact-field">

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -193,11 +193,9 @@
 
 		socket.on('node_data', function (msg) {
 			for (i = 0; i < msg.frequency.length; i++) {
-				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
 				$('.node_peak_rssi_' + i).html(msg.node_peak_rssi[i]);
 				$('.pass_peak_rssi_' + i).html(msg.pass_peak_rssi[i]);
 
-				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				d5rt.nodes[i].frequency = msg.frequency[i];
 				d5rt.nodes[i].node_peak_rssi = msg.node_peak_rssi[i];
 				d5rt.nodes[i].pass_peak_rssi = msg.pass_peak_rssi[i];
@@ -596,7 +594,6 @@
 						<tr>
 							<td class="rssi" colspan="2">
 								<span class="current_rssi_{{ node }}"></span> /
-								<span class="trigger_rssi_{{ node }}"></span> /
 								<span class="node_peak_rssi_{{ node }}"></span> /
 								<span class="pass_peak_rssi_{{ node }}"></span>
 							</td>

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -32,7 +32,7 @@
 			'current_heat'
 		]});
 
-		var heatbeatCounter = 0;
+		var heartbeatCounter = 0;
 
 		// set admin flag
 		d5rt.admin = true;
@@ -145,8 +145,8 @@
 					checkSpeakQueueFlag = true;
 			}
 
-			if (++heatbeatCounter >= 2) {   //do these updates less often than speak-queue checks
-				heatbeatCounter = 0;
+			if (++heartbeatCounter >= 2) {   //do these updates less often than speak-queue checks
+				heartbeatCounter = 0;
 
 				if (d5rt.collecting) {
 					var timedump = {

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -8,7 +8,7 @@
 			'pilot_data',
 			'race_format',
 			'node_tuning',
-			'node_offsets',
+			'enter_and_exit_at_levels',
 			'min_lap'
 		]});
 
@@ -85,15 +85,15 @@
 		socket.on('node_data', function (msg) {
 			for (i = 0; i < msg.frequency.length; i++) {
 				$('#s_channel_' + i).val(msg.frequency[i]);
-				$('.trigger_rssi_' + i).html(msg.trigger_rssi[i]);
 				$('.node_peak_rssi_' + i).html(msg.node_peak_rssi[i]);
 				$('.pass_peak_rssi_' + i).html(msg.pass_peak_rssi[i]);
+				$('.pass_nadir_rssi_' + i).html(msg.pass_nadir_rssi[i]);
 				$('.debug_pass_count_' + i).html(msg.debug_pass_count[i]);
 
-				d5rt.nodes[i].trigger_rssi = msg.trigger_rssi[i];
 				d5rt.nodes[i].frequency = msg.frequency[i];
 				d5rt.nodes[i].node_peak_rssi = msg.node_peak_rssi[i];
 				d5rt.nodes[i].pass_peak_rssi = msg.pass_peak_rssi[i];
+				d5rt.nodes[i].pass_nadir_rssi = msg.pass_nadir_rssi[i];
 				/*
 				d5rt.nodes[i].calibration_threshold = msg.trigger_rssi[i] - parseInt($('#set_calibration_threshold').val());
 				d5rt.nodes[i].trigger_threshold = msg.trigger_rssi[i] - parseInt($('#set_trigger_threshold').val());
@@ -113,11 +113,23 @@
 			}
 		});
 
-		socket.on('node_offsets', function (msg) {
-			for (i = 0; i < msg.node_offsets.length; i++) {
-				$('#set_node_offset_' + i).val(msg.node_offsets[i]);
-				d5rt.nodes[i].offset = msg.node_offsets[i];
+		socket.on('enter_and_exit_at_levels', function (msg) {
+			for (i = 0; i < msg.enter_at_levels.length; i++) {
+				$('#set_enter_at_level_' + i).val(msg.enter_at_levels[i]);
+				d5rt.nodes[i].enter_at_level = msg.enter_at_levels[i];
+				$('#set_exit_at_level_' + i).val(msg.exit_at_levels[i]);
+				d5rt.nodes[i].exit_at_level = msg.exit_at_levels[i];
 			}
+		});
+
+		socket.on('node_enter_at_level', function (msg) {
+			$('#set_enter_at_level_' + msg.node_index).val(msg.level);
+			d5rt.nodes[msg.node_index].enter_at_level = msg.level;
+		});
+
+		socket.on('node_exit_at_level', function (msg) {
+			$('#set_exit_at_level_' + msg.node_index).val(msg.level);
+			d5rt.nodes[msg.node_index].exit_at_level = msg.level;
 		});
 
 		$('.set_frequency').change(function (event) {
@@ -135,13 +147,44 @@
 			}
 		});
 
-		$('.set_node_offset').change(function (event) {
+		$('.set_enter_at_level').change(function (event) {
 			var data = {
 				node: parseInt($(this).data('node')),
-				node_offset: parseInt($(this).val()),
+				enter_at_level: parseInt($(this).val()),
 			};
-			socket.emit('set_node_offset', data);
-			d5rt.nodes[data.node].offset = data.node_offset;
+			if (!Number.isNaN(data.enter_at_level)) {
+				socket.emit('set_enter_at_level', data);
+				d5rt.nodes[data.node].enter_at_level = data.enter_at_level;
+			}
+		});
+
+		$('.set_exit_at_level').change(function (event) {
+			var data = {
+				node: parseInt($(this).data('node')),
+				exit_at_level: parseInt($(this).val()),
+			};
+			if (!Number.isNaN(data.exit_at_level)) {
+				socket.emit('set_exit_at_level', data);
+				d5rt.nodes[data.node].exit_at_level = data.exit_at_level;
+			}
+		});
+
+		$('button#cap_enter_at_btn').click(function (event) {
+			var data = {
+				node_index: parseInt($(this).data('node_index')),
+			};
+			$('#set_enter_at_level_' + data.node_index).val('');
+			socket.emit('cap_enter_at_btn', data);
+			return false;
+		});
+
+		$('button#cap_exit_at_btn').click(function (event) {
+			var data = {
+				node_index: parseInt($(this).data('node_index')),
+			};
+			$('#set_exit_at_level_' + data.node_index).val('');
+			socket.emit('cap_exit_at_btn', data);
+			return false;
 		});
 
 		/* Heats */
@@ -650,12 +693,23 @@
 
 							<div class="compact-field">
 								<label for="s_channel_{{ node }}">Frequency</label>
-								<input type="number" id="s_channel_{{ node }}" class="set_frequency" data-node="{{ node }}" min="5300" max="6001">
+								<input type="number" id="s_channel_{{ node }}" class="set_frequency" data-node="{{ node }}" min="5000" max="6001">
 							</div>
 
 							<div class="compact-field">
-								<label for="set_node_offset_{{ node }}">Offset</label>
-								<input type="number" id="set_node_offset_{{ node }}" class="set_node_offset" data-node="{{ node }}" min="-999" max="999">
+								<label for="set_enter_at_level_{{ node }}">EnterAt</label>
+								<input type="number" id="set_enter_at_level_{{ node }}" class="set_enter_at_level" data-node="{{ node }}" min="0" max="999">
+							</div>
+							<div class="control-set">
+								<button type="button" class="btn btn-default" id="cap_enter_at_btn" data-node_index="{{ node }}" onclick="this.blur();">Capture^</button>
+							</div>
+
+							<div class="compact-field">
+								<label for="set_exit_at_level_{{ node }}">ExitAt</label>
+								<input type="number" id="set_exit_at_level_{{ node }}" class="set_exit_at_level" data-node="{{ node }}" min="0" max="999">
+							</div>
+							<div class="control-set">
+								<button type="button" class="btn btn-default" id="cap_exit_at_btn" data-node_index="{{ node }}" onclick="this.blur();">Capture^</button>
 							</div>
 						</td>
 					</tr>
@@ -663,12 +717,6 @@
 						<td class="datalabel">RSSI</td>
 						<td>
 							<span class="current_rssi_{{ node }}"></span>
-						</td>
-					</tr>
-					<tr>
-						<td class="datalabel">Trigger</td>
-						<td>
-							<span class="trigger_rssi_{{ node }}"></span>
 						</td>
 					</tr>
 					<tr>
@@ -681,6 +729,12 @@
 						<td class="datalabel">PassPeak</td>
 						<td>
 							<span class="pass_peak_rssi_{{ node }}"></span>
+						</td>
+					</tr>
+					<tr>
+						<td class="datalabel">PassNadir</td>
+						<td>
+							<span class="pass_nadir_rssi_{{ node }}"></span>
 						</td>
 					</tr>
 					<tr>
@@ -896,7 +950,7 @@
 					<label for="set_filter_ratio">Filter Ratio</label>
 					<p class="desc">RSSI Smoothing: .0001 smoothest, 1.0 unfiltered. (Default 0.01)</p>
 				</div>
-				<input type="number" id="set_filter_ratio" min=".0001" max="6.5535" step="0.0001">
+				<input type="number" id="set_filter_ratio" min="0.0001" max="1.0" step="0.0001">
 			</li>
 		</ol>
 

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -12,7 +12,7 @@
 			'min_lap'
 		]});
 
-		var heatbeatCounter = 0;
+		var heartbeatCounter = 0;
 
 		// set admin flag
 		d5rt.admin = true;
@@ -41,8 +41,8 @@
 		});
 
 		socket.on('heartbeat', function (msg) {
-			if (++heatbeatCounter >= 2) {   //do these updates less often than speak-queue checks
-				heatbeatCounter = 0;
+			if (++heartbeatCounter >= 2) {   //do these updates less often than speak-queue checks
+				heartbeatCounter = 0;
 				for (i = 0; i < msg.current_rssi.length; i++) {
 					var rssiValue = msg.current_rssi[i];
 


### PR DESCRIPTION
Initial implementation for EnterAt/ExitAt with capture

Changed delta5node.ino to have MARK_START_TIME and return 'lap ms-since-start'

Changed delta5server to use 'lap ms-since-start' (if node API_level >= 10)

If node API_level < 10 then only reading of RSSI is supported (no write commands)

Added min/max check to RSSI readings

Changed READ/WRITE_FILTER_RATIO to use 16-bit value and added range checks

Added try/except around server 'run()'

Note:  Global tuning parameters are still shown but not used (other than FilterRatio); they need to be removed

--ET