### PR TITLE
Added 'Number of Laps to Win' option to race formats

### DIFF
--- a/src/delta5node/delta5node.ino
+++ b/src/delta5node/delta5node.ino
@@ -373,14 +373,18 @@ void loop()
 
         // Find the peak rssi and the time it occured during a crossing event
         // Use the raw value to account for the delay in smoothing.
-        if (state.rssiRaw > state.passRssiPeakRaw)
+        if (state.rssiRaw >= state.passRssiPeakRaw)
         {
-            state.passRssiPeakRaw = state.rssiRaw;
-            state.passRssiPeakRawTime = millis();
-        }
-
-        if (state.rssiRaw == state.passRssiPeakRaw) {
+            // if at max peak for more than one iteration then track first
+            //  and last timestamp so middle-timestamp value can be returned
             state.passRssiPeakRawLastTime = millis();
+
+            if (state.rssiRaw > state.passRssiPeakRaw)
+            {
+                // this is first time this peak-raw-RSSI value was seen, so save value and timestamp
+                state.passRssiPeakRaw = state.rssiRaw;
+                state.passRssiPeakRawTime = state.passRssiPeakRawLastTime;
+            }
         }
 
         // track lowest smoothed rssi seen since end of last pass

--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -1,5 +1,5 @@
 '''Delta5 race timer server script'''
-SERVER_API = 2 # Server API version
+SERVER_API = 3 # Server API version
 
 import os
 import sys

--- a/src/delta5server/templates/database.html
+++ b/src/delta5server/templates/database.html
@@ -129,6 +129,7 @@
             <td>{{ raceformat.hide_stage_timer }}</td>
             <td>{{ raceformat.start_delay_min }}</td>
             <td>{{ raceformat.start_delay_max }}</td>
+            <td>{{ raceformat.number_laps_win }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -296,6 +296,10 @@
 			speak('<div class="speech">' + ttstext + '</div>');
 		})
 
+		socket.on('phonetic_text', function (msg) {
+			speak('<div class="speech">' + msg.text + '</div>');
+		})
+
 		socket.on('current_heat', function (msg) {
 			$('.current_heat').html('Heat ' + msg.current_heat);
 			for (i = 0; i < msg.callsign.length; i++) {

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -437,6 +437,7 @@
 			$('#set_hide_stage_timer').val(msg.hide_stage_timer);
 			$('#set_start_delay_min').val(msg.start_delay_min);
 			$('#set_start_delay_max').val(msg.start_delay_max);
+			$('#set_number_laps_win').val(msg.number_laps_win);
 		});
 
 		$('#set_race_format').change(function (event) {
@@ -496,6 +497,13 @@
 				start_delay_max: parseInt($(this).val())
 			};
 			socket.emit('set_start_delay_max', data);
+		})
+
+		$('#set_number_laps_win').change(function (event) {
+			var data = {
+				number_laps_win: parseInt($(this).val())
+			};
+			socket.emit('set_number_laps_win', data);
 		})
 
 		/* Calibration Profiles */
@@ -934,6 +942,12 @@
 					<p class="desc">Maximum time before race begins</p>
 				</div>
 				<input type="number" id="set_start_delay_max" min="0" max="999">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_number_laps_win">Number of Laps to Win</label>
+				</div>
+				<input type="number" id="set_number_laps_win" min="0" max="999">
 			</li>
 		</ol>
 


### PR DESCRIPTION
Initial implementation that calls out name of winning pilot or team

'check_team_laps_win()' could be improved to do 'crossing' checks like what 'check_pilot_laps_win()' does

Renamed duplicate fns to 'on_set_start_delay_min' and 'on_set_start_delay_max' in 'server.py'

--ET