### PR TITLE
Support for timed most-laps-wins races, etc

### DIFF
--- a/src/delta5server/server.py
+++ b/src/delta5server/server.py
@@ -1,5 +1,5 @@
 '''Delta5 race timer server script'''
-SERVER_API = 5 # Server API version
+SERVER_API = 6 # Server API version
 
 import os
 import sys

--- a/src/delta5server/static/d5rt.js
+++ b/src/delta5server/static/d5rt.js
@@ -100,6 +100,7 @@ LogSlider.prototype = {
 var d5rt = {
 	language: '', // local language for voice callout
 	voice_volume: 1.0, // voice call volume
+	voice_callsign: true, // speak pilot callsigns
 	voice_lap_count: true, // speak lap counts
 	voice_team_lap_count: true, // speak team lap counts
 	voice_lap_time: true, // speak lap times
@@ -122,6 +123,7 @@ var d5rt = {
 		}
 		localStorage['d5rt.language'] = JSON.stringify(this.language);
 		localStorage['d5rt.voice_volume'] = JSON.stringify(this.voice_volume);
+		localStorage['d5rt.voice_callsign'] = JSON.stringify(this.voice_callsign);
 		localStorage['d5rt.voice_lap_count'] = JSON.stringify(this.voice_lap_count);
 		localStorage['d5rt.voice_team_lap_count'] = JSON.stringify(this.voice_team_lap_count);
 		localStorage['d5rt.voice_lap_time'] = JSON.stringify(this.voice_lap_time);
@@ -142,6 +144,9 @@ var d5rt = {
 			}
 			if (localStorage['d5rt.voice_volume']) {
 				this.voice_volume = JSON.parse(localStorage['d5rt.voice_volume']);
+			}
+			if (localStorage['d5rt.voice_callsign']) {
+				this.voice_callsign = JSON.parse(localStorage['d5rt.voice_callsign']);
 			}
 			if (localStorage['d5rt.voice_lap_count']) {
 				this.voice_lap_count = JSON.parse(localStorage['d5rt.voice_lap_count']);

--- a/src/delta5server/templates/build_timer.html
+++ b/src/delta5server/templates/build_timer.html
@@ -185,6 +185,7 @@
 						if (buzzer)
 							buzzer.play(); // End race buzzer
 						timer.stop();
+						socket.emit('race_time_finished');  // signal server
 					} else if (time <= 5) {
 						if (stagebuzzer)
 							stagebuzzer.play(); // Final seconds

--- a/src/delta5server/templates/race.html
+++ b/src/delta5server/templates/race.html
@@ -44,6 +44,7 @@
 		$('nav li').removeClass('admin-hide');
 
 		// populate voice controls
+		$('#voice_callsign').prop( "checked", d5rt.voice_callsign);
 		$('#voice_lap_count').prop( "checked", d5rt.voice_lap_count);
 		$('#voice_team_lap_count').prop( "checked", d5rt.voice_team_lap_count);
 		$('#voice_lap_time').prop( "checked", d5rt.voice_lap_time);
@@ -271,7 +272,7 @@
 		socket.on('phonetic_data', function (msg) {
 			var ttstext = '';
 
-			if (d5rt.voice_lap_count || d5rt.voice_lap_time) {
+			if (d5rt.voice_callsign) {
 				ttstext = msg.callsign;
 				if (msg.pilot)
 					ttstext = msg.pilot;
@@ -407,6 +408,11 @@
 
 		$('.set_language').change(function (event) {
 			d5rt.language = $(this).val();
+			d5rt.saveData();
+		});
+
+		$('#voice_callsign').change(function (event) {
+			d5rt.voice_callsign = $(this).prop('checked');
 			d5rt.saveData();
 		});
 
@@ -787,6 +793,7 @@
 					Announcements
 				</div>
 				<ul>
+					<li><label><input type="checkbox" id="voice_callsign"> Callsign</label></li>
 					<li><label><input type="checkbox" id="voice_lap_count"> Lap Number</label></li>
 					<li><label><input type="checkbox" id="voice_lap_time"> Lap Time</label></li>
 					<li><label><input type="checkbox" id="voice_race_timer"> Race Timer</label></li>

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -26,6 +26,7 @@
 		$('nav li').removeClass('admin-hide');
 
 		// populate voice controls
+		$('#voice_callsign').prop( "checked", d5rt.voice_callsign);
 		$('#voice_lap_count').prop( "checked", d5rt.voice_lap_count);
 		$('#voice_team_lap_count').prop( "checked", d5rt.voice_team_lap_count);
 		$('#voice_lap_time').prop( "checked", d5rt.voice_lap_time);
@@ -505,6 +506,11 @@
 
 		$('#set_language').change(function (event) {
 			d5rt.language = $(this).val();
+			d5rt.saveData();
+		});
+
+		$('#voice_callsign').change(function (event) {
+			d5rt.voice_callsign = $(this).prop('checked');
 			d5rt.saveData();
 		});
 
@@ -1064,6 +1070,7 @@
 					Announcements
 				</div>
 				<ul>
+					<li><label><input type="checkbox" id="voice_callsign"> Callsign</label></li>
 					<li><label><input type="checkbox" id="voice_lap_count"> Lap Number</label></li>
 					<li><label><input type="checkbox" id="voice_lap_time"> Lap Time</label></li>
 					<li><label><input type="checkbox" id="voice_race_timer"> Race Timer</label></li>

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -610,6 +610,8 @@
 			$('#set_start_delay_max').prop('disabled', msg.locked);
 			$('#set_number_laps_win').val(msg.number_laps_win);
 			$('#set_number_laps_win').prop('disabled', msg.locked);
+			$('#set_laps_wins_mode').val(msg.laps_wins_mode);
+			$('#set_laps_wins_mode').prop('disabled', msg.locked);
 		});
 
 		$('#set_race_format').change(function (event) {
@@ -676,6 +678,13 @@
 				number_laps_win: parseInt($(this).val())
 			};
 			socket.emit('set_number_laps_win', data);
+		})
+
+		$('#set_laps_wins_mode').change(function (event) {
+			var data = {
+				laps_wins_mode: parseInt($(this).val())
+			};
+			socket.emit('set_laps_wins_mode', data);
 		})
 
 		/* Database Reset */
@@ -1177,6 +1186,15 @@
 					<label for="set_number_laps_win">Number of Laps to Win</label>
 				</div>
 				<input type="number" id="set_number_laps_win" min="0" max="999">
+			</li>
+			<li>
+				<div class="label-block">
+					<label for="set_laps_wins_mode">Laps Wins Mode</label>
+				</div>
+				<select id="set_laps_wins_mode">
+					<option value="0">Most Laps Wins Disabled</option>
+					<option value="1">Most Laps Wins Enabled</option>
+				</select>
 			</li>
 		</ol>
 

--- a/src/delta5server/templates/settings.html
+++ b/src/delta5server/templates/settings.html
@@ -1184,6 +1184,7 @@
 			<li>
 				<div class="label-block">
 					<label for="set_number_laps_win">Number of Laps to Win</label>
+					<p class="desc">Used if Most Laps Wins Disabled</p>
 				</div>
 				<input type="number" id="set_number_laps_win" min="0" max="999">
 			</li>


### PR DESCRIPTION
Initial support for timed most-laps-wins races.

Restored callsign-voice-call checkbox so team callout can include (just) it with team name and lap_id

Mods for team laps races

Made team number-laps-win tracking check lap timestamp and crossing flag

Moved some 'currentProfile' fetches out of 'for-node' loops

Implemented team support for Most Laps Wins race and did other mods/improvements

Updated SERVER_API to 6

--ET